### PR TITLE
[Feat] 응답 통일, 예외 처리 

### DIFF
--- a/src/main/java/final_project/momeasy/domain/calendar/exception/CalendarErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/calendar/exception/CalendarErrorCode.java
@@ -1,0 +1,21 @@
+package final_project.momeasy.domain.calendar.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum CalendarErrorCode implements BaseErrorCode {
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "CALENDAR400_1", "캘린더 정보를 수정할 수 없습니다"),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "CALENDAR400_2", "캘린더 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "CALENDAR401", "캘린더에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "CALENDAR404", "캘린더를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "CALENDAR409", "이미 등록된 캘린더입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CALENDAR500", "캘린더 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/calendar/exception/CalendarException.java
+++ b/src/main/java/final_project/momeasy/domain/calendar/exception/CalendarException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.calendar.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class CalendarException extends CustomException {
+    public CalendarException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/child/exception/ChildErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/child/exception/ChildErrorCode.java
@@ -1,0 +1,21 @@
+package final_project.momeasy.domain.child.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ChildErrorCode implements BaseErrorCode {
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "CHILD400_1", "아이 정보를 수정할 수 없습니다"),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "CHILD400_2", "아이 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "CHILD401", "아이에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "CHILD404", "아이를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "CHILD409", "이미 등록된 아이입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CHILD500", "아이 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/child/exception/ChildException.java
+++ b/src/main/java/final_project/momeasy/domain/child/exception/ChildException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.child.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class ChildException extends CustomException {
+    public ChildException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/exception/FeverRecordErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/exception/FeverRecordErrorCode.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.fever_record.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum FeverRecordErrorCode implements BaseErrorCode {
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "FEVER_RECORD400_2", "체온 기록 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "FEVER_RECORD401", "체온 기록에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "FEVER_RECORD404", "체온 기록을 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FEVER_RECORD500", "체온 기록 처리 중 서버 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/exception/FeverRecordException.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/exception/FeverRecordException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.fever_record.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class FeverRecordException extends CustomException {
+    public FeverRecordException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/exception/FeverReportErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/exception/FeverReportErrorCode.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.fever_report.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum FeverReportErrorCode implements BaseErrorCode {
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "FEVER_RECORD400_2", "발열 리포트 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "FEVER_RECORD401", "발열 리포트에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "FEVER_RECORD404", "발열 리포트를 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FEVER_RECORD500", "발열 리포트 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/exception/FeverReportException.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/exception/FeverReportException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.fever_report.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class FeverReportException extends CustomException {
+    public FeverReportException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/home_cam/exception/HomecamErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/exception/HomecamErrorCode.java
@@ -1,0 +1,22 @@
+package final_project.momeasy.domain.home_cam.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum HomecamErrorCode implements BaseErrorCode {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "HOMECAM404", "홈캠을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "HOMECAM409", "이미 등록된 홈캠입니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "HOMECAM404", "홈캠에 접근할 수 있는 권한이 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "HOMECAM500", "홈캠 처리 중 서버 오류가 발생했습니다"),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "HOMECAM4002", "홈캠 정보를 수정할 수 없습니다"),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "HOMECAM4003", "홈캠 정보를 삭제할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/final_project/momeasy/domain/home_cam/exception/HomecamErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/exception/HomecamErrorCode.java
@@ -8,12 +8,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum HomecamErrorCode implements BaseErrorCode {
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "HOMECAM400_1", "홈캠 정보를 수정할 수 없습니다"),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "HOMECAM400_2", "홈캠 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "HOMECAM401", "홈캠에 접근할 수 있는 권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "HOMECAM404", "홈캠을 찾을 수 없습니다."),
     ALREADY_ADD(HttpStatus.CONFLICT, "HOMECAM409", "이미 등록된 홈캠입니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "HOMECAM404", "홈캠에 접근할 수 있는 권한이 없습니다."),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "HOMECAM500", "홈캠 처리 중 서버 오류가 발생했습니다"),
-    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "HOMECAM4002", "홈캠 정보를 수정할 수 없습니다"),
-    DELETE_FAILED(HttpStatus.BAD_REQUEST, "HOMECAM4003", "홈캠 정보를 삭제할 수 없습니다.");
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "HOMECAM500", "홈캠 처리 중 서버 오류가 발생했습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/final_project/momeasy/domain/home_cam/exception/HomecamException.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/exception/HomecamException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.home_cam.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class HomecamException extends CustomException {
+    public HomecamException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/illness/exception/IllnessErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/illness/exception/IllnessErrorCode.java
@@ -1,0 +1,21 @@
+package final_project.momeasy.domain.illness.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum IllnessErrorCode implements BaseErrorCode {
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "ILLNESS400_1", "질환 정보를 수정할 수 없습니다"),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "ILLNESS400_2", "질환 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "ILLNESS401", "질환에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "ILLNESS404", "질환를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "ILLNESS409", "이미 등록된 캘린더입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ILLNESS500", "질환 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/illness/exception/IllnessException.java
+++ b/src/main/java/final_project/momeasy/domain/illness/exception/IllnessException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.illness.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class IllnessException extends CustomException{
+    public IllnessException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.notification.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum NotificationErrorCode implements BaseErrorCode {
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "NOTIFICATION400_2", "알림 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "NOTIFICATION401", "알림에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404", "알림를 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION500", "알림 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/notification/exception/NotificationException.java
+++ b/src/main/java/final_project/momeasy/domain/notification/exception/NotificationException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.notification.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class NotificationException extends CustomException {
+    public NotificationException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/outing_record/exception/OutingRecordErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/outing_record/exception/OutingRecordErrorCode.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.outing_record.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum OutingRecordErrorCode implements BaseErrorCode {
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "OUTING_RECORD400_2", "외출 기록 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "OUTING_RECORD401", "외출 기록에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "OUTING_RECORD404", "외출 기록을 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OUTING_RECORD500", "외출 기록 처리 중 서버 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/outing_record/exception/OutingRecordException.java
+++ b/src/main/java/final_project/momeasy/domain/outing_record/exception/OutingRecordException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.outing_record.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class OutingRecordException extends CustomException {
+    public OutingRecordException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
@@ -1,0 +1,24 @@
+package final_project.momeasy.domain.parent.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ParentErrorCode implements BaseErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "PARENT400", "필수 동의사항에 모두 동의해야 회원가입이 가능합니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "PARENT401_1", "비밀번호가 일치하지 않습니다."),
+    WROND_ID(HttpStatus.UNAUTHORIZED, "PARENT401_2", "아이디가 일치하지 않습니다."),
+    WROND_CODE(HttpStatus.UNAUTHORIZED, "PARENT401_3", "인증번호가 일치하지 않습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "PARENT401_4", "회원 정보를 수정/삭제할 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT404", "회원을 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "PARENT409_1", "이미 사용 중인 이메일입니다."),
+    DUPLICATE_ID(HttpStatus.CONFLICT, "PARENT409_2", "이미 사용중인 아이디입니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/parent/exception/ParentException.java
+++ b/src/main/java/final_project/momeasy/domain/parent/exception/ParentException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.parent.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class ParentException extends CustomException {
+    public ParentException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/exception/RoomConditionErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/exception/RoomConditionErrorCode.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.room_condition.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum RoomConditionErrorCode implements BaseErrorCode {
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "ROOM_CONDITION400_2", "온습도 기록 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "ROOM_CONDITION401", "온습도 기록에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM_CONDITION404", "온습도 기록을 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ROOM_CONDITION500", "온습도 기록 처리 중 서버 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/exception/RoomConditionException.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/exception/RoomConditionException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.room_condition.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class RoomConditionException extends CustomException {
+    public RoomConditionException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/setting/exception/SettingErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/setting/exception/SettingErrorCode.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.setting.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum SettingErrorCode implements BaseErrorCode {
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "SETTING400_1", "설정 정보를 수정할 수 없습니다"),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "SETTING401", "설정에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "SETTING404", "설정를 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SETTING500", "설정 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/setting/exception/SettingException.java
+++ b/src/main/java/final_project/momeasy/domain/setting/exception/SettingException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.setting.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class SettingException extends CustomException {
+    public SettingException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/symptom/exception/SymptomErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/symptom/exception/SymptomErrorCode.java
@@ -1,0 +1,21 @@
+package final_project.momeasy.domain.symptom.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum SymptomErrorCode implements BaseErrorCode {
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "SYMPTOM400_1", "증상 정보를 수정할 수 없습니다"),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "SYMPTOM400_2", "증상 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "SYMPTOM401", "증상에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "SYMPTOM404", "증상를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "SYMPTOM409", "이미 등록된 캘린더입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYMPTOM500", "증상 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/symptom/exception/SymptomException.java
+++ b/src/main/java/final_project/momeasy/domain/symptom/exception/SymptomException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.symptom.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class SymptomException extends CustomException {
+    public SymptomException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/apiPayload/CustomResponse.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/CustomResponse.java
@@ -1,0 +1,42 @@
+package final_project.momeasy.global.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"isSuccess", "code","message","result"})
+public class CustomResponse<T> {
+    @JsonProperty("isSuccess")
+    private boolean isSuccess;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("result")
+    private final T result;
+
+    // 200 OK를 사용하는 성공 응답
+    public static <T> CustomResponse<T> onSuccess(T result) {
+        return new CustomResponse<>(true, String.valueOf(HttpStatus.OK.value()), HttpStatus.OK.getReasonPhrase(),result);
+    }
+    // 상태 코드를 받아서 사용하는 성공 응답
+    public static <T> CustomResponse<T> onSuccess(HttpStatus status, T result) {
+        return new CustomResponse<>(true, String.valueOf(status.value()), status.getReasonPhrase(), result);
+    }
+    // 실패 응답 ( 데이터 포함 )
+    public static <T> CustomResponse<T> onFailure(String code, String message, T result) {
+        return new CustomResponse<>(false,code,message,result);
+    }
+    // 실패 응답 ( 데이터 없음 )
+    public static <T> CustomResponse<T> onFailure(String code, String message) {
+        return new CustomResponse<>(false,code,message,null);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.global.apiPayload.code;
+
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/final_project/momeasy/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,28 @@
+package final_project.momeasy.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum GeneralErrorCode implements BaseErrorCode {
+    BAD_REQUEST_400(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다"),
+
+    UNAUTHORIZED_401(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다"),
+
+    FORBIDDEN_403(HttpStatus.FORBIDDEN, "COMMON403", "접근이 금지되었습니다"),
+
+    NOT_FOUND_404(HttpStatus.NOT_FOUND, "COMMON404", "요청한 자원을 찾을 수 없습니다"),
+
+    INTERNAL_SERVER_ERROR_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다"),
+
+    // 유효성 검사
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALID400_0", "잘못된 파라미터 입니다.")
+    ;
+
+    // 필요한 필드값 선언
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/global/apiPayload/exception/CustomException.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/exception/CustomException.java
@@ -1,11 +1,16 @@
 package final_project.momeasy.global.apiPayload.exception;
 
 import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class CustomException extends RuntimeException {
     private final BaseErrorCode code;
 
-    public CustomException(BaseErrorCode errorcode) {this.code = errorcode;}
+    @Override
+    public String getMessage() {
+        return code.getMessage();
+    }
 }

--- a/src/main/java/final_project/momeasy/global/apiPayload/exception/CustomException.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/exception/CustomException.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.global.apiPayload.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final BaseErrorCode code;
+
+    public CustomException(BaseErrorCode errorcode) {this.code = errorcode;}
+}

--- a/src/main/java/final_project/momeasy/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package final_project.momeasy.global.apiPayload.exception.handler;
+
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.code.GeneralErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+import jakarta.validation.ConstraintViolation;
+import lombok.extern.slf4j.Slf4j;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomResponse<String>> handleCustomException(CustomException ex) {
+        log.error("[ CustomException ]: {} ", ex.getCode().getMessage());
+        BaseErrorCode errorCode = ex.getCode();
+        CustomResponse<String> errorResponse = CustomResponse.onFailure(errorCode.getCode(), ex.getMessage());
+        return ResponseEntity.status(ex.getCode().getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CustomResponse<List<String>>> constraintViolationException(ConstraintViolationException ex) {
+        log.error(Arrays.toString(ex.getStackTrace()));
+        List<String> message = ex.getConstraintViolations().stream().map(ConstraintViolation::getMessage).toList();
+
+        log.error("[ ConstraintViolationException ]: {} ", message);
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST_400;
+        CustomResponse<List<String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(),null);
+
+        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CustomResponse<Map<String,String>>> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        Map<String, String> error = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(fieldError -> error.put(fieldError.getField(), fieldError.getDefaultMessage()));
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST_400;
+        log.error("[ MethodArgumentNotValidException ]: {} ", error);
+        CustomResponse<Map<String,String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(),error);
+        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomResponse<String>> handleException(Exception ex) {
+        log.error("[WARNING] Internal Server Error: {}", ex.getMessage());
+        BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR_500;
+        CustomResponse<String> errorResponse = CustomResponse.onFailure(errorCode.getCode(), ex.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] global 응답 통일, 예외 처리
- [x] entity 별 예외 처리  

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요

응답 통일, 엔티티 별 예외 처리 구현
  <br/>

## 이미지 첨부
실패했을 경우 응답

![image](https://github.com/user-attachments/assets/5aaf71ba-6330-4867-b6cd-2cbdb2ff6495)

성공했을 경우 응답

![image](https://github.com/user-attachments/assets/d6d686de-8164-448a-9bec-889d0317eeaf)

<br/>


## ➕ 이슈 링크

- [server #5 ](https://github.com/SMU-25/server/issues/5#issue-3059467543)

<br/>
