### PR TITLE
:hammer: [Refactor] 홈캠, 자식 관계 추가

### DIFF
--- a/src/main/java/final_project/momeasy/domain/child/entity/Child.java
+++ b/src/main/java/final_project/momeasy/domain/child/entity/Child.java
@@ -4,9 +4,9 @@ import final_project.momeasy.common.enums.Gender;
 import final_project.momeasy.domain.fever_record.entity.FeverRecord;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
 import final_project.momeasy.domain.home_cam.entity.Homecam;
-import final_project.momeasy.domain.illness.entity.Illness;
 import final_project.momeasy.domain.notification.entity.Notification;
 import final_project.momeasy.domain.outing_record.entity.OutingRecord;
+import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.parent.entity.ParentChild;
 import final_project.momeasy.common.enums.Seizure;
 import final_project.momeasy.domain.room_condition.entity.RoomCondition;
@@ -75,5 +75,12 @@ public class Child extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "child", cascade = CascadeType.ALL)
     @Builder.Default
     private List<FeverReport> fever_reports = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY,mappedBy = "child")
+    private Homecam homecam;
+
+    public void setHomecam(Homecam homecam) {
+        this.homecam = homecam;
+    }
 
 }

--- a/src/main/java/final_project/momeasy/domain/home_cam/entity/Homecam.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/entity/Homecam.java
@@ -1,5 +1,6 @@
 package final_project.momeasy.domain.home_cam.entity;
 
+import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.parent.entity.Parent;
 import jakarta.persistence.*;
 import lombok.*;
@@ -28,8 +29,17 @@ public class Homecam {
     @JoinColumn(name = "parent_id",nullable = false)
     private Parent parent;
 
+    @OneToOne(fetch =FetchType.LAZY,cascade = CascadeType.ALL)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Child child;
+
     public void setParent(Parent parent) {
         this.parent = parent;
         parent.getHomecams().add(this);
+    }
+
+    public void setChild(Child child) {
+        this.child = child;
+        child.setHomecam(this);
     }
 }

--- a/src/test/java/final_project/momeasy/domain/home_cam/repository/HomecamRepositoryTest.java
+++ b/src/test/java/final_project/momeasy/domain/home_cam/repository/HomecamRepositoryTest.java
@@ -1,6 +1,9 @@
 package final_project.momeasy.domain.home_cam.repository;
 
 import final_project.momeasy.common.enums.Gender;
+import final_project.momeasy.common.enums.Seizure;
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.repository.ChildRepository;
 import final_project.momeasy.domain.home_cam.entity.Homecam;
 import final_project.momeasy.domain.parent.entity.Parent;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +29,13 @@ class HomecamRepositoryTest {
     @Autowired
     private HomecamRepository homecamRepository;
 
+    @Autowired
+    private ChildRepository childRepository;
+
     private Parent parent;
+    private Child child;
+    private Child child2;
+    private Child child3;
     private Homecam homecam1;
     private Homecam homecam2;
     private Homecam homecam3;
@@ -44,6 +53,35 @@ class HomecamRepositoryTest {
                 .build();
         entityManager.persist(parent);
 
+        child = Child.builder()
+                .name("testChild")
+                .birthdate(LocalDate.now())
+                .height(100)
+                .weight(20.0f)
+                .gender(Gender.BOY)
+                .seizure(Seizure.NONE)
+                .build();
+        child = entityManager.persist(child);
+
+        child2 = Child.builder()
+                .name("testChild2")
+                .birthdate(LocalDate.now())
+                .height(101)
+                .weight(22.0f)
+                .gender(Gender.BOY)
+                .seizure(Seizure.NONE)
+                .build();
+        child2 = entityManager.persist(child2);
+
+        child3 = Child.builder()
+                .name("testChild3")
+                .birthdate(LocalDate.now())
+                .height(102)
+                .weight(23.0f)
+                .gender(Gender.BOY)
+                .seizure(Seizure.NONE)
+                .build();
+        child3 = entityManager.persist(child3);
         // 홈캠 생성
         homecam1 = Homecam.builder()
                 .name("Living Room Camera")
@@ -53,6 +91,7 @@ class HomecamRepositoryTest {
                 .video_url("http://example.com/video1")
                 .build();
         homecam1.setParent(parent);
+        homecam1.setChild(child);
 
         homecam2 = Homecam.builder()
                 .name("Bedroom Camera")
@@ -62,6 +101,7 @@ class HomecamRepositoryTest {
                 .video_url("http://example.com/video2")
                 .build();
         homecam2.setParent(parent);
+        homecam2.setChild(child2);
 
         homecam3 = Homecam.builder()
                 .name("Kitchen Camera")
@@ -71,6 +111,7 @@ class HomecamRepositoryTest {
                 .video_url("http://example.com/video3")
                 .build();
         homecam3.setParent(parent);
+        homecam3.setChild(child3);
 
         entityManager.persist(homecam1);
         entityManager.persist(homecam2);
@@ -125,5 +166,26 @@ class HomecamRepositoryTest {
 
         // then
         assertThat(foundHomecam).isEmpty();
+    }
+
+    @Test
+    void checkChildhasHomecam(){
+        // when
+        Optional<Child> foundChild1 = childRepository.findById(child.getId());
+        Optional<Child> foundChild2 = childRepository.findById(child2.getId());
+        Optional<Child> foundChild3 = childRepository.findById(child3.getId());
+
+        // then
+        assertThat(foundChild1.get().getHomecam().getName()).isEqualTo("Living Room Camera");
+        assertThat(foundChild1.get().getHomecam().getSerial_num()).isEqualTo("SN12345");
+        assertThat(foundChild1.get().getHomecam().getPlace()).isEqualTo("Living Room");
+
+        assertThat(foundChild2.get().getHomecam().getName()).isEqualTo("Bedroom Camera");
+        assertThat(foundChild2.get().getHomecam().getSerial_num()).isEqualTo("SN67890");
+        assertThat(foundChild2.get().getHomecam().getPlace()).isEqualTo("Bedroom");
+
+        assertThat(foundChild3.get().getHomecam().getName()).isEqualTo("Kitchen Camera");
+        assertThat(foundChild3.get().getHomecam().getSerial_num()).isEqualTo("SN24680");
+        assertThat(foundChild3.get().getHomecam().getPlace()).isEqualTo("Kitchen");
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] 홈캠과 자식에 1:1 관계 추가
- [x] 테스트 완료 

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요
홈캠과 자식 관계 1:1 추가
### 추가 이유
    자식에게 온습도, 발열 기록을 추가하기 이전에 홈캠이 있는지 확인해야함.
    기존 방식으로는 자식의 부모가 홈캠이 있는지 확인( 자식 - 부모 - 홈캠 -> 쿼리문 많음), 
    부모가 홈캠이 있다고 해도 부모가 여러 자식이 있다면 어떤 자식을 위한 홈캠인지 모름
    자식과 홈캠에 1:1 관계를 추가함으로 자식에게 홈캠이 있는지 쉽게 확인 ( 자식 - 홈캠 쿼리문 감소 ).

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/a81fb8c3-9f12-401b-9a0e-b968f6784024)

<br/>


## ➕ 이슈 링크

- [server #10 ](https://github.com/SMU-25/server/issues/10#issue-3065911145)

<br/>
