### PR TITLE
:sparkles: [Feat] 체온 기록 조회, 삭제, 생성 구현

### DIFF
--- a/src/main/java/final_project/momeasy/MomeasyApplication.java
+++ b/src/main/java/final_project/momeasy/MomeasyApplication.java
@@ -3,9 +3,11 @@ package final_project.momeasy;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class MomeasyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/final_project/momeasy/domain/fever_record/controller/FeverRecordController.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/controller/FeverRecordController.java
@@ -1,0 +1,36 @@
+package final_project.momeasy.domain.fever_record.controller;
+
+import final_project.momeasy.domain.fever_record.dto.FeverRecordResponseDTO;
+import final_project.momeasy.domain.fever_record.service.FeverRecordQueryService;
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import jakarta.persistence.Column;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feverRecord")
+public class FeverRecordController {
+    private final FeverRecordQueryService feverRecordQueryService;
+
+    @GetMapping("/{child_id}")
+    public CustomResponse<FeverRecordResponseDTO.FeverRecordViewDTO> getFeverRecord(@PathVariable("child_id") Long childId) {
+        FeverRecordResponseDTO.FeverRecordViewDTO feverRecordViewDTO = feverRecordQueryService.getFeverRecord(childId);
+        return CustomResponse.onSuccess(feverRecordViewDTO);
+    }
+
+    @GetMapping("/list/{child_id}")
+    public CustomResponse<List<FeverRecordResponseDTO.FeverRecordViewDTO>>getFeverRecordPage(@PathVariable("child_id") Long childId,
+         @RequestParam(value="page", defaultValue="0") int page) {
+        List<FeverRecordResponseDTO.FeverRecordViewDTO> feverRecordViewList = feverRecordQueryService.getFeverRecordPage(childId,page);
+        return CustomResponse.onSuccess(feverRecordViewList);
+    }
+
+    @GetMapping("/all/{child_id}")
+    public CustomResponse<List<FeverRecordResponseDTO.FeverRecordViewDTO>>getFeverRecordList(@PathVariable("child_id") Long childId) {
+        List<FeverRecordResponseDTO.FeverRecordViewDTO> feverRecordViewList = feverRecordQueryService.getFeverRecordList(childId);
+        return CustomResponse.onSuccess(feverRecordViewList);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/converter/FeverRecordConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/converter/FeverRecordConverter.java
@@ -1,0 +1,21 @@
+package final_project.momeasy.domain.fever_record.converter;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.fever_record.dto.FeverRecordRequestDTO;
+import final_project.momeasy.domain.fever_record.dto.FeverRecordResponseDTO;
+import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+
+public class FeverRecordConverter {
+    public static FeverRecord toFeverRecord(FeverRecordRequestDTO.FeverRecordCreateDTO feverRecordCreateDTO, Child child) {
+        return FeverRecord.builder()
+                .fever(feverRecordCreateDTO.getFever())
+                .child(child)
+                .build();
+    }
+
+    public static FeverRecordResponseDTO.FeverRecordViewDTO toFeverRecordResponseDTO(FeverRecord feverRecord) {
+        return FeverRecordResponseDTO.FeverRecordViewDTO.builder()
+                .fever(feverRecord.getFever())
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/dto/FeverRecordRequestDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/dto/FeverRecordRequestDTO.java
@@ -1,0 +1,12 @@
+package final_project.momeasy.domain.fever_record.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FeverRecordRequestDTO {
+    @Getter
+    @Builder
+    public static class FeverRecordCreateDTO{
+        private float fever;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/dto/FeverRecordResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/dto/FeverRecordResponseDTO.java
@@ -1,0 +1,12 @@
+package final_project.momeasy.domain.fever_record.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FeverRecordResponseDTO {
+    @Getter
+    @Builder
+    public static class FeverRecordViewDTO{
+        private float fever;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordRepository.java
@@ -10,14 +10,16 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface FeverRecordRepository extends JpaRepository<FeverRecord, Long> {
     Optional<FeverRecord> findTopByChildIdOrderByIdDesc(Long childId);
     Slice<FeverRecord> findAllByChildIdOrderByIdDesc(Long childId, Pageable pageable);
+    List<FeverRecord> findAllByChildId(Long childId);
 
     @Transactional
     @Modifying
-    @Query("DELETE FROM FeverRecord fr WHERE fr.createdAt < :time") //스케줄링(@Scheduled)과 함께 사용, 30일 분량의 데이터만 저장
+    @Query("DELETE FROM FeverRecord fr WHERE fr.createdAt < :time") //스케줄링(@Scheduled)과 함께 사용, 7일 분량의 데이터만 저장
     void deleteByCreatedAtBefore(@Param("time") LocalDateTime time);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordQueryService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordQueryService.java
@@ -1,0 +1,13 @@
+package final_project.momeasy.domain.fever_record.service;
+
+import final_project.momeasy.domain.fever_record.dto.FeverRecordResponseDTO;
+
+import java.util.List;
+
+public interface FeverRecordQueryService {
+    FeverRecordResponseDTO.FeverRecordViewDTO getFeverRecord(Long childId);
+
+    List<FeverRecordResponseDTO.FeverRecordViewDTO> getFeverRecordPage(Long childId, int page);
+
+    List<FeverRecordResponseDTO.FeverRecordViewDTO> getFeverRecordList(Long childId);
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordQueryServiceImpl.java
@@ -1,0 +1,50 @@
+package final_project.momeasy.domain.fever_record.service;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_record.converter.FeverRecordConverter;
+import final_project.momeasy.domain.fever_record.dto.FeverRecordRequestDTO;
+import final_project.momeasy.domain.fever_record.dto.FeverRecordResponseDTO;
+import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+import final_project.momeasy.domain.fever_record.exception.FeverRecordErrorCode;
+import final_project.momeasy.domain.fever_record.exception.FeverRecordException;
+import final_project.momeasy.domain.fever_record.repository.FeverRecordRepository;
+import final_project.momeasy.domain.parent.repository.ParentRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class FeverRecordQueryServiceImpl implements FeverRecordQueryService {
+    private final FeverRecordRepository feverRecordRepository;
+    private final ChildRepository childRepository;
+
+    // 아이에게 홈캠이 있는지 예외 처리 필요
+    @Override
+    public FeverRecordResponseDTO.FeverRecordViewDTO getFeverRecord(Long childId) {
+        FeverRecord feverRecord = feverRecordRepository.findTopByChildIdOrderByIdDesc(childId).orElseThrow(()->new FeverRecordException(FeverRecordErrorCode.NOT_FOUND));
+        if(feverRecord.getChild()!= childRepository.findById(childId).get()) {
+            throw new FeverRecordException(FeverRecordErrorCode.NOT_FOUND);
+        }
+        return FeverRecordConverter.toFeverRecordResponseDTO(feverRecord);
+    }
+
+    @Override
+    public List<FeverRecordResponseDTO.FeverRecordViewDTO> getFeverRecordPage(Long childId, int page) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
+        Slice<FeverRecord> feverRecords = feverRecordRepository.findAllByChildIdOrderByIdDesc(childId,pageRequest);
+        List<FeverRecordResponseDTO.FeverRecordViewDTO> feverRecordsDTO = feverRecords.stream().map(FeverRecordConverter::toFeverRecordResponseDTO).toList();
+        return feverRecordsDTO;
+    }
+
+    @Override
+    public List<FeverRecordResponseDTO.FeverRecordViewDTO> getFeverRecordList(Long childId) {
+        List<FeverRecord> feverRecords = feverRecordRepository.findAllByChildId(childId);
+        List<FeverRecordResponseDTO.FeverRecordViewDTO> feverRecordsDTO = feverRecords.stream().map(FeverRecordConverter::toFeverRecordResponseDTO).toList();
+        return feverRecordsDTO;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordService.java
@@ -1,0 +1,46 @@
+package final_project.momeasy.domain.fever_record.service;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+import final_project.momeasy.domain.fever_record.repository.FeverRecordRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+@Transactional
+public class FeverRecordService {
+    private final FeverRecordRepository feverRecordRepository;
+    private final ChildRepository childRepository;
+
+    // // 아이에게 홈캠이 있는지 예외 처리 필요, for문에 센서로 데이터 입력 받아야함
+    @Scheduled(cron = "0 * * * * *")
+    public void createFeverRecord(){
+        log.info("Starting scheduled create Fever Record");
+        List<Child> childList = childRepository.findAll();
+        for(Child child : childList){
+            FeverRecord feverRecord = FeverRecord.builder()
+                    .fever(36.5f)
+                    .build();
+            feverRecord.setChild(child);
+            feverRecordRepository.save(feverRecord);
+            log.info(child.getName()+" ("+feverRecord.getId()+") Fever Record created");
+        }
+    }
+
+    @Scheduled(cron ="0 * * * * *")
+    public void deleteFeverRecord(){
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        LocalDateTime thirtySecondsAgo = LocalDateTime.now().minusSeconds(30);
+        feverRecordRepository.deleteByCreatedAtBefore(thirtySecondsAgo);
+        log.info("Fever Record deleted");
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] 체온 기록 DTO, converter, service, controller 구현
- [x] 체온 기록 조회, 삭제, 생성 구현
- [x] 삭제, 생성은 Scheduler로 구현
- [x] 전체 조회를 위한 함수 repository에 추가
- [x] 테스트 완료
 
  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요


      1. 체온 기록 응답, 요청 DTO 구현
      2. DTO <-> Entity 변경 converter 생성 
      3. 체온 기록 controller, service 구현 - 조회 기능 구현
      4. 삭제, 생성 Scheduler 구현 - 매분 데이터 입력, 7일동안의 데이터만 유지, 나머지 삭제
  <br/>

## 이미지 첨부
### FeverRecordService.java
![image](https://github.com/user-attachments/assets/4c1afff1-3217-437a-a5c3-57ea3add7675)
createFeverRecord는 매분 실행되어 체온 기록 데이터 db에 저장
deleteFeverRecord는 정각마다 실행되어 7일동안의 데이터만 유지, 나머지 삭제
<br/>


## ➕ 이슈 링크

- [server #9 ](https://github.com/SMU-25/server/issues/9#issue-3064978303)

<br/>
