### PR TITLE
:sparkles: [Feat] 온습도 기록 조회, 삭제, 생성 구현

### DIFF
--- a/src/main/java/final_project/momeasy/domain/room_condition/controller/RoomConditionController.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/controller/RoomConditionController.java
@@ -1,0 +1,35 @@
+package final_project.momeasy.domain.room_condition.controller;
+
+import final_project.momeasy.domain.room_condition.dto.RoomConditionResponseDTO;
+import final_project.momeasy.domain.room_condition.service.RoomConditionQueryService;
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/room")
+public class RoomConditionController {
+    private final RoomConditionQueryService roomConditionQueryService;
+
+    @GetMapping("/{child_id}")
+    public CustomResponse<RoomConditionResponseDTO.RoomConditionViewDTO> getRoomCondition(@PathVariable("child_id") Long childId) {
+        RoomConditionResponseDTO.RoomConditionViewDTO roomConditionViewDTO = roomConditionQueryService.getRoomCondition(childId);
+        return CustomResponse.onSuccess(roomConditionViewDTO);
+    }
+
+    @GetMapping("list/{child_id}")
+    public CustomResponse<List<RoomConditionResponseDTO.RoomConditionViewDTO>> getRoomConditionPage(@PathVariable("child_id") Long childId
+    ,@RequestParam(value="page", defaultValue="0") int page) {
+        List<RoomConditionResponseDTO.RoomConditionViewDTO> roomConditionViewList = roomConditionQueryService.getRoomConditionPage(childId, page);
+        return CustomResponse.onSuccess(roomConditionViewList);
+    }
+
+    @GetMapping("all/{child_id}")
+    public CustomResponse<List<RoomConditionResponseDTO.RoomConditionViewDTO>> getRoomConditionList(@PathVariable("child_id") Long childId) {
+        List<RoomConditionResponseDTO.RoomConditionViewDTO> roomConditionViewList= roomConditionQueryService.getRoomConditionList(childId);
+        return CustomResponse.onSuccess(roomConditionViewList);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/converter/RoomConditionConverter.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/converter/RoomConditionConverter.java
@@ -1,0 +1,23 @@
+package final_project.momeasy.domain.room_condition.converter;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.room_condition.dto.RoomConditionRequestDTO;
+import final_project.momeasy.domain.room_condition.dto.RoomConditionResponseDTO;
+import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+
+public class RoomConditionConverter {
+    public static RoomConditionResponseDTO.RoomConditionViewDTO toRoomConditionViewDTO(RoomCondition roomCondition) {
+        return RoomConditionResponseDTO.RoomConditionViewDTO.builder()
+                .temperature(roomCondition.getTemperature())
+                .humidity(roomCondition.getHumidity())
+                .build();
+    }
+
+    public static RoomCondition toRoomCondition(RoomConditionRequestDTO.RoomConditionCreateDTO roomConditionCreateDTO, Child child) {
+        return RoomCondition.builder()
+                .temperature(roomConditionCreateDTO.getTemperature())
+                .humidity(roomConditionCreateDTO.getHumidity())
+                .child(child)
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/dto/RoomConditionRequestDTO.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/dto/RoomConditionRequestDTO.java
@@ -1,0 +1,14 @@
+package final_project.momeasy.domain.room_condition.dto;
+
+import jakarta.persistence.Column;
+import lombok.Builder;
+import lombok.Getter;
+
+public class RoomConditionRequestDTO {
+    @Getter
+    @Builder
+    public static class RoomConditionCreateDTO {
+        private float temperature;
+        private float humidity;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/dto/RoomConditionResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/dto/RoomConditionResponseDTO.java
@@ -1,0 +1,13 @@
+package final_project.momeasy.domain.room_condition.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class RoomConditionResponseDTO {
+    @Getter
+    @Builder
+    public static class RoomConditionViewDTO {
+        private float temperature;
+        private float humidity;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/repository/RoomConditionRepository.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/repository/RoomConditionRepository.java
@@ -10,11 +10,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomConditionRepository extends JpaRepository<RoomCondition, Long> {
     Optional<RoomCondition> findTopByChildIdOrderByIdDesc(Long childId);
     Slice<RoomCondition> findAllByChildIdOrderByIdDesc(Long childId, Pageable pageable);
+    List<RoomCondition> findAllByChildId(Long childId);
 
     @Transactional
     @Modifying

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryService.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryService.java
@@ -1,0 +1,13 @@
+package final_project.momeasy.domain.room_condition.service;
+
+import final_project.momeasy.domain.room_condition.dto.RoomConditionResponseDTO;
+
+import java.util.List;
+
+public interface RoomConditionQueryService {
+    RoomConditionResponseDTO.RoomConditionViewDTO getRoomCondition(Long childId);
+
+    List<RoomConditionResponseDTO.RoomConditionViewDTO> getRoomConditionPage(Long childId, int page);
+
+    List<RoomConditionResponseDTO.RoomConditionViewDTO> getRoomConditionList(Long childId);
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryServiceImpl.java
@@ -1,0 +1,60 @@
+package final_project.momeasy.domain.room_condition.service;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.exception.ChildErrorCode;
+import final_project.momeasy.domain.child.exception.ChildException;
+import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_record.exception.FeverRecordErrorCode;
+import final_project.momeasy.domain.home_cam.exception.HomecamException;
+import final_project.momeasy.domain.home_cam.repository.HomecamRepository;
+import final_project.momeasy.domain.room_condition.converter.RoomConditionConverter;
+import final_project.momeasy.domain.room_condition.dto.RoomConditionResponseDTO;
+import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+import final_project.momeasy.domain.room_condition.exception.RoomConditionErrorCode;
+import final_project.momeasy.domain.room_condition.exception.RoomConditionException;
+import final_project.momeasy.domain.room_condition.repository.RoomConditionRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class RoomConditionQueryServiceImpl implements RoomConditionQueryService {
+    private final RoomConditionRepository roomConditionRepository;
+    private final ChildRepository childRepository;
+    private final HomecamRepository homecamRepository;
+
+    @Override
+    public RoomConditionResponseDTO.RoomConditionViewDTO getRoomCondition(Long childId) {
+        RoomCondition roomCondition =
+                roomConditionRepository.findTopByChildIdOrderByIdDesc(childId).orElseThrow(()->new RoomConditionException(RoomConditionErrorCode.NOT_FOUND));
+        Child child = childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        if(roomCondition.getChild()!=child){
+            throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        return RoomConditionConverter.toRoomConditionViewDTO(roomCondition);
+    }
+
+    @Override
+    public List<RoomConditionResponseDTO.RoomConditionViewDTO> getRoomConditionPage(Long childId, int page) {
+        homecamRepository.findById(childId).orElseThrow(()->new HomecamException(RoomConditionErrorCode.NOT_FOUND));
+        Pageable pageable = PageRequest.of(page, 10);
+        Slice<RoomCondition> roomConditionList = roomConditionRepository.findAllByChildIdOrderByIdDesc(childId, pageable);
+        List<RoomConditionResponseDTO.RoomConditionViewDTO> roomConditionViewDTOList = roomConditionList.stream()
+                .map(RoomConditionConverter::toRoomConditionViewDTO).toList();
+        return roomConditionViewDTOList;
+    }
+
+    @Override
+    public List<RoomConditionResponseDTO.RoomConditionViewDTO> getRoomConditionList(Long childId) {
+        homecamRepository.findById(childId).orElseThrow(()->new HomecamException(RoomConditionErrorCode.NOT_FOUND));
+        List<RoomCondition> roomConditionList = roomConditionRepository.findAllByChildId(childId);
+        List<RoomConditionResponseDTO.RoomConditionViewDTO> roomConditionViewDTOList = roomConditionList.stream()
+                .map(RoomConditionConverter::toRoomConditionViewDTO).toList();
+        return roomConditionViewDTOList;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionService.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionService.java
@@ -1,0 +1,46 @@
+package final_project.momeasy.domain.room_condition.service;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+import final_project.momeasy.domain.room_condition.repository.RoomConditionRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+@Transactional
+public class RoomConditionService {
+    private final RoomConditionRepository roomConditionRepository;
+    private final ChildRepository childRepository;
+
+    // // 아이에게 홈캠이 있는지 예외 처리 필요, for문에 센서로 데이터 입력 받아야함
+    @Scheduled(cron = "0 * * * * *")
+    public void createRoomCondition() {
+        log.info("Starting scheduled create Room Condition");
+        List<Child> childList = childRepository.findAll();
+        for(Child child : childList){
+            RoomCondition roomCondition = RoomCondition.builder()
+                    .temperature(36.5f)
+                    .humidity(50.0f)
+                    .build();
+            roomCondition.setChild(child);
+            roomConditionRepository.save(roomCondition);
+            log.info(child.getName()+" ("+roomCondition.getId()+") Room Condition created");
+        }
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteRoomCondition(){
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        roomConditionRepository.deleteByCreatedAtBefore(sevenDaysAgo);
+        log.info("Room Condition deleted");
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] 온습도 기록 DTO, converter, service, controller 구현
- [x] 온습도 기록 조회, 삭제, 생성 구현
- [x] 삭제, 생성은 Scheduler로 구현
- [x] 전체 조회를 위한 함수 repository에 추가
- [x] 테스트 완료

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요

      1. 온습도 기록 응답, 요청 DTO 구현
      2. DTO <-> Entity 변경 converter 생성 
      3. 온습도 기록 controller, service 구현 - 조회 기능 구현
      4. 삭제, 생성 Scheduler 구현 - 매분 데이터 입력, 7일동안의 데이터만 유지, 나머지 삭제
  <br/>

## 이미지 첨부

--

<br/>


## ➕ 이슈 링크

- [server#13](https://github.com/SMU-25/server/issues/13#issue-3067833605)

<br/>
