### PR TITLE
:sparkles: [Feat] 발열 리포트 조회, 삭제, 생성 구현

### DIFF
--- a/src/main/java/final_project/momeasy/domain/fever_report/controller/FeverReportController.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/controller/FeverReportController.java
@@ -1,0 +1,49 @@
+package final_project.momeasy.domain.fever_report.controller;
+
+import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+import final_project.momeasy.domain.fever_report.service.FeverReportQueryService;
+import final_project.momeasy.domain.fever_report.service.FeverReportService;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class FeverReportController {
+    private final FeverReportService feverReportService;
+    private final FeverReportQueryService feverReportQueryService;
+
+    @GetMapping("/{child_id}/{report_id}")
+    public CustomResponse<FeverReportResponseDTO.FeverReportViewDTO> getFeverReport(@AuthenticationPrincipal Parent parent,
+        @PathVariable("child_id") long childId, @PathVariable("report_id") long reportId) {
+        FeverReportResponseDTO.FeverReportViewDTO feverReportViewDTO = feverReportQueryService.getFeverReport(parent, childId, reportId);
+        return CustomResponse.onSuccess(feverReportViewDTO);
+    }
+
+    @GetMapping("/{child_id}/list")
+    public CustomResponse<List<FeverReportResponseDTO.FeverReportViewDTO>> getFeverReports(@AuthenticationPrincipal Parent parent,
+         @PathVariable("child_id") long childId, @RequestParam(value="page", defaultValue="0") int page) {
+        List<FeverReportResponseDTO.FeverReportViewDTO> feverReportViewDTOList = feverReportQueryService.getFeverReports(parent,childId,page);
+        return CustomResponse.onSuccess(feverReportViewDTOList);
+    }
+
+    @DeleteMapping("/{child_id}/{report_id}")
+    public CustomResponse<Void> deleteFeverReport(@AuthenticationPrincipal Parent parent,
+     @PathVariable("child_id") long childId, @PathVariable("report_id") long reportId){
+        feverReportService.deleteFeverReport(parent,reportId,childId);
+        return CustomResponse.onSuccess(null);
+    }
+
+    @PostMapping("/{child_id}/posts")
+    public CustomResponse<FeverReportResponseDTO.FeverReportViewDTO> createFeverReport(@AuthenticationPrincipal Parent parent,
+    @RequestBody FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, @PathVariable("child_id") long childId) {
+        FeverReportResponseDTO.FeverReportViewDTO feverReportViewDTO = feverReportService.createFeverReport(parent, feverReportRequestDTO, childId);
+        return CustomResponse.onSuccess(feverReportViewDTO);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/controller/FeverReportController.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/controller/FeverReportController.java
@@ -40,7 +40,7 @@ public class FeverReportController {
         return CustomResponse.onSuccess(null);
     }
 
-    @PostMapping("/{child_id}/posts")
+    @PostMapping("/{child_id}")
     public CustomResponse<FeverReportResponseDTO.FeverReportViewDTO> createFeverReport(@AuthenticationPrincipal Parent parent,
     @RequestBody FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, @PathVariable("child_id") long childId) {
         FeverReportResponseDTO.FeverReportViewDTO feverReportViewDTO = feverReportService.createFeverReport(parent, feverReportRequestDTO, childId);

--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -1,27 +1,30 @@
 package final_project.momeasy.domain.fever_report.converter;
 
 
+import final_project.momeasy.common.enums.SymptomType;
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
 import final_project.momeasy.domain.fever_report.entity.FeverReportSymptom;
+import final_project.momeasy.domain.symptom.entity.Symptom;
+
+import java.util.List;
 
 public class FeverReportConverter {
-    public static FeverReportResponseDTO.FeverReportViewDTO toFeverReportViewDTO(FeverReport feverReport,String special) {
+    public static FeverReportResponseDTO.FeverReportViewDTO toFeverReportViewDTO(FeverReport feverReport) {
         return FeverReportResponseDTO.FeverReportViewDTO.builder()
                 .outing(feverReport.getOuting())
-                .special(special)
+                .special(feverReport.getSpecial())
                 .etc_symptom(feverReport.getEtc_symptom())
-                .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom::getSymptom).toList())
+                .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom -> FeverReportSymptom.getSymptom().getSymptom()).toList())
                 .build();
     }
 
-    public static FeverReport toFeverReport(FeverReportRequestDTO.FeverReportCreateDTO feverReportCreateDTO, Child child, String special) {
+    public static FeverReport toFeverReport(FeverReportRequestDTO.FeverReportCreateDTO feverReportCreateDTO, String special) {
         return FeverReport.builder()
                 .outing(feverReportCreateDTO.getOuting())
                 .special(special)
-                .child(child)
                 .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -1,0 +1,27 @@
+package final_project.momeasy.domain.fever_report.converter;
+
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.fever_report.entity.FeverReportSymptom;
+
+public class FeverReportConverter {
+    public static FeverReportResponseDTO.FeverReportViewDTO toFeverReportViewDTO(FeverReport feverReport,String special) {
+        return FeverReportResponseDTO.FeverReportViewDTO.builder()
+                .outing(feverReport.getOuting())
+                .special(special)
+                .etc_symptom(feverReport.getEtc_symptom())
+                .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom::getSymptom).toList())
+                .build();
+    }
+
+    public static FeverReport toFeverReport(FeverReportRequestDTO.FeverReportCreateDTO feverReportCreateDTO, Child child, String special) {
+        return FeverReport.builder()
+                .outing(feverReportCreateDTO.getOuting())
+                .special(special)
+                .child(child)
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -1,15 +1,10 @@
 package final_project.momeasy.domain.fever_report.converter;
 
 
-import final_project.momeasy.common.enums.SymptomType;
-import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
-import final_project.momeasy.domain.fever_report.entity.FeverReportSymptom;
-import final_project.momeasy.domain.symptom.entity.Symptom;
 
-import java.util.List;
 
 public class FeverReportConverter {
     public static FeverReportResponseDTO.FeverReportViewDTO toFeverReportViewDTO(FeverReport feverReport) {

--- a/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportRequestDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportRequestDTO.java
@@ -1,6 +1,6 @@
 package final_project.momeasy.domain.fever_report.dto;
 
-import final_project.momeasy.domain.symptom.entity.Symptom;
+import final_project.momeasy.common.enums.SymptomType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -13,7 +13,7 @@ public class FeverReportRequestDTO {
     @Builder
     public static class FeverReportCreateDTO {
         @NotBlank(message = "증상은 필수 입력 값입니다.")
-        private List<Symptom> symptoms;
+        private List<SymptomType> symptoms;
 
         private String etc_symptom;
 

--- a/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportRequestDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportRequestDTO.java
@@ -1,0 +1,23 @@
+package final_project.momeasy.domain.fever_report.dto;
+
+import final_project.momeasy.domain.symptom.entity.Symptom;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class FeverReportRequestDTO {
+    @Getter
+    @Builder
+    public static class FeverReportCreateDTO {
+        @NotBlank(message = "증상은 필수 입력 값입니다.")
+        private List<Symptom> symptoms;
+
+        private String etc_symptom;
+
+        @NotNull(message = "외출 기록은 필수 입력 값입니다.")
+        private String outing;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
@@ -1,0 +1,23 @@
+package final_project.momeasy.domain.fever_report.dto;
+
+import final_project.momeasy.domain.symptom.entity.Symptom;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+public class FeverReportResponseDTO {
+    @Getter
+    @Builder
+    public static class FeverReportViewDTO {
+        private List<Symptom> symptoms;
+
+        private String etc_symptom;
+
+        private String outing;
+
+        private String special;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
@@ -1,8 +1,6 @@
 package final_project.momeasy.domain.fever_report.dto;
 
-import final_project.momeasy.domain.symptom.entity.Symptom;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import final_project.momeasy.common.enums.SymptomType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,7 +10,7 @@ public class FeverReportResponseDTO {
     @Getter
     @Builder
     public static class FeverReportViewDTO {
-        private List<Symptom> symptoms;
+        private List<SymptomType> symptoms;
 
         private String etc_symptom;
 

--- a/src/main/java/final_project/momeasy/domain/fever_report/repository/FeverReportRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/repository/FeverReportRepository.java
@@ -9,6 +9,5 @@ import java.util.Optional;
 
 public interface FeverReportRepository extends JpaRepository<FeverReport, Long> {
     Optional<FeverReport> findById(Long id);
-    Optional<FeverReport> findByChildId(Long childId);
     Slice<FeverReport> findAllByChildIdOrderByIdDesc(Long ChildId, Pageable pageable);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/repository/FeverReportRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/repository/FeverReportRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 public interface FeverReportRepository extends JpaRepository<FeverReport, Long> {
     Optional<FeverReport> findById(Long id);
-    Slice<FeverReport> findAllByOrderByIdDesc(Pageable pageable);
+    Optional<FeverReport> findByChildId(Long childId);
+    Slice<FeverReport> findAllByChildIdOrderByIdDesc(Long ChildId, Pageable pageable);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryService.java
@@ -1,11 +1,11 @@
 package final_project.momeasy.domain.fever_report.service;
 
-import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+import final_project.momeasy.domain.parent.entity.Parent;
 
 import java.util.List;
 
 public interface FeverReportQueryService {
-    FeverReportResponseDTO.FeverReportViewDTO getFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long childId);
-    List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(FeverReportRequestDTO feverReportRequestDTO, Long childId, int page);
+    FeverReportResponseDTO.FeverReportViewDTO getFeverReport(Parent parent, Long childId, Long reportId);
+    List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(Parent parent, Long childId, int page);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryService.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.fever_report.service;
+
+import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+
+import java.util.List;
+
+public interface FeverReportQueryService {
+    FeverReportResponseDTO.FeverReportViewDTO getFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long childId);
+    List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(FeverReportRequestDTO feverReportRequestDTO, Long childId, int page);
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
@@ -1,12 +1,17 @@
 package final_project.momeasy.domain.fever_report.service;
 
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.exception.ChildErrorCode;
+import final_project.momeasy.domain.child.exception.ChildException;
+import final_project.momeasy.domain.child.repository.ChildRepository;
 import final_project.momeasy.domain.fever_report.converter.FeverReportConverter;
-import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
 import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
 import final_project.momeasy.domain.fever_report.exception.FeverReportException;
 import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.parent.entity.ParentChild;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,20 +24,41 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FeverReportQueryServiceImpl implements FeverReportQueryService {
     private final FeverReportRepository feverReportRepository;
+    private final ChildRepository childRepository;
 
     @Override
-    public FeverReportResponseDTO.FeverReportViewDTO getFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long childId) {
-        FeverReport feverReport = feverReportRepository.findByChildId(childId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
-        String special = "특이 사항";
-        return FeverReportConverter.toFeverReportViewDTO(feverReport,special);
+    public FeverReportResponseDTO.FeverReportViewDTO getFeverReport(Parent parent, Long childId, Long reportId) {
+        Child child = childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        List<ParentChild> parentChildren = child.getParentChildren();
+        FeverReport feverReport = null;
+        for (ParentChild parentChild : parentChildren) {
+            if(parentChild.getParent().getId().equals(parent.getId())) {
+                feverReport = feverReportRepository.findById(reportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+                break;
+            }
+        }
+        if(feverReport == null) {
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        return FeverReportConverter.toFeverReportViewDTO(feverReport);
     }
 
     @Override
-    public List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(FeverReportRequestDTO feverReportRequestDTO, Long childId, int page) {
+    public List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(Parent parent, Long childId, int page) {
         Pageable pageable = PageRequest.of(page,10);
-        String special = "특이 사항";
-        Slice<FeverReport> feverReportSlice = feverReportRepository.findAllByChildIdOrderByIdDesc(childId,pageable);
-        List<FeverReportResponseDTO.FeverReportViewDTO> feverReportList = feverReportSlice.stream().map(feverReport -> FeverReportConverter.toFeverReportViewDTO(feverReport,special)).toList();
+        Child child = childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        List<ParentChild> parentChildren = child.getParentChildren();
+        Slice<FeverReport> feverReportSlice = null;
+        for(ParentChild parentChild : parentChildren) {
+            if(parentChild.getParent().getId().equals(parent.getId())) {
+                feverReportSlice = feverReportRepository.findAllByChildIdOrderByIdDesc(childId,pageable);
+                break;
+            }
+        }
+        if(feverReportSlice == null) {
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        List<FeverReportResponseDTO.FeverReportViewDTO> feverReportList = feverReportSlice.stream().map(feverReport -> FeverReportConverter.toFeverReportViewDTO(feverReport)).toList();
         return feverReportList;
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
@@ -1,0 +1,38 @@
+package final_project.momeasy.domain.fever_report.service;
+
+import final_project.momeasy.domain.fever_report.converter.FeverReportConverter;
+import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
+import final_project.momeasy.domain.fever_report.exception.FeverReportException;
+import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FeverReportQueryServiceImpl implements FeverReportQueryService {
+    private final FeverReportRepository feverReportRepository;
+
+    @Override
+    public FeverReportResponseDTO.FeverReportViewDTO getFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long childId) {
+        FeverReport feverReport = feverReportRepository.findByChildId(childId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+        String special = "특이 사항";
+        return FeverReportConverter.toFeverReportViewDTO(feverReport,special);
+    }
+
+    @Override
+    public List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(FeverReportRequestDTO feverReportRequestDTO, Long childId, int page) {
+        Pageable pageable = PageRequest.of(page,10);
+        String special = "특이 사항";
+        Slice<FeverReport> feverReportSlice = feverReportRepository.findAllByChildIdOrderByIdDesc(childId,pageable);
+        List<FeverReportResponseDTO.FeverReportViewDTO> feverReportList = feverReportSlice.stream().map(feverReport -> FeverReportConverter.toFeverReportViewDTO(feverReport,special)).toList();
+        return feverReportList;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportService.java
@@ -1,0 +1,9 @@
+package final_project.momeasy.domain.fever_report.service;
+
+import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+
+public interface FeverReportService {
+    void deleteFeverReport(Long FeverReportId, Long ChildId);
+    FeverReportResponseDTO.FeverReportViewDTO createFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long ChildId);
+}

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportService.java
@@ -2,8 +2,9 @@ package final_project.momeasy.domain.fever_report.service;
 
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+import final_project.momeasy.domain.parent.entity.Parent;
 
 public interface FeverReportService {
-    void deleteFeverReport(Long FeverReportId, Long ChildId);
-    FeverReportResponseDTO.FeverReportViewDTO createFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long ChildId);
+    void deleteFeverReport(Parent parent, Long FeverReportId, Long ChildId);
+    FeverReportResponseDTO.FeverReportViewDTO createFeverReport(Parent parent, FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, Long ChildId);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
@@ -1,36 +1,77 @@
 package final_project.momeasy.domain.fever_report.service;
 
+import final_project.momeasy.common.enums.SymptomType;
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.child.exception.ChildErrorCode;
 import final_project.momeasy.domain.child.exception.ChildException;
 import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_report.converter.FeverReportConverter;
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
 import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
 import final_project.momeasy.domain.fever_report.exception.FeverReportException;
 import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.parent.entity.ParentChild;
+import final_project.momeasy.domain.symptom.entity.Symptom;
+import final_project.momeasy.domain.symptom.repository.SymptomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FeverReportServiceImpl implements FeverReportService {
     private final FeverReportRepository feverReportRepository;
     private final ChildRepository childRepository;
+    private final SymptomRepository symptomRepository;
 
     @Override
-    public void deleteFeverReport(Long FeverReportId, Long ChildId) {
-        FeverReport feverReport = feverReportRepository.findById(FeverReportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+    public void deleteFeverReport(Parent parent, Long FeverReportId, Long ChildId) {
+
         Child child = childRepository.findById(ChildId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if(feverReport.getChild()!=child){
+        List<ParentChild> parentChildren = child.getParentChildren();
+        FeverReport feverReport = null;
+        for (ParentChild parentChild : parentChildren) {
+            if(parentChild.getParent().getId().equals(parent.getId())) {
+                feverReport = feverReportRepository.findById(FeverReportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+                break;
+            }
+        }
+        if(feverReport == null || feverReport.getChild()!=child) {
             throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
         }
         feverReportRepository.deleteById(FeverReportId);
     }
 
     @Override
-    public FeverReportResponseDTO.FeverReportViewDTO createFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long ChildId) {
+    public FeverReportResponseDTO.FeverReportViewDTO createFeverReport(Parent parent, FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, Long ChildId) {
+        Child child = childRepository.findById(ChildId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        List<ParentChild> parentChildren = child.getParentChildren();
+        FeverReport feverReport = null;
+        String special = "특이 사항";
+        for (ParentChild parentChild : parentChildren) {
+            if(parentChild.getParent().getId().equals(parent.getId())) {
+                feverReport = FeverReportConverter.toFeverReport(feverReportRequestDTO,special);
+                feverReport.setChild(child);
+                feverReportRepository.save(feverReport);
+                for(SymptomType symptomtype: feverReportRequestDTO.getSymptoms()) {
+                    Symptom symptom = Symptom.builder()
+                            .symptom(symptomtype)
+                            .build();
+                    symptom.addFeverReport(feverReport);
+                    symptomRepository.save(symptom);
+                }
+                break;
+            }
+        }
+        if(feverReport == null) {
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
+        }
         return null;
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
@@ -1,0 +1,36 @@
+package final_project.momeasy.domain.fever_report.service;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.exception.ChildErrorCode;
+import final_project.momeasy.domain.child.exception.ChildException;
+import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
+import final_project.momeasy.domain.fever_report.exception.FeverReportException;
+import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeverReportServiceImpl implements FeverReportService {
+    private final FeverReportRepository feverReportRepository;
+    private final ChildRepository childRepository;
+
+    @Override
+    public void deleteFeverReport(Long FeverReportId, Long ChildId) {
+        FeverReport feverReport = feverReportRepository.findById(FeverReportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+        Child child = childRepository.findById(ChildId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        if(feverReport.getChild()!=child){
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        feverReportRepository.deleteById(FeverReportId);
+    }
+
+    @Override
+    public FeverReportResponseDTO.FeverReportViewDTO createFeverReport(FeverReportRequestDTO feverReportRequestDTO, Long ChildId) {
+        return null;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/symptom/entity/Symptom.java
+++ b/src/main/java/final_project/momeasy/domain/symptom/entity/Symptom.java
@@ -22,9 +22,6 @@ public class Symptom {
     @Column(nullable = false)
     private SymptomType symptom;
 
-    @Column(nullable = false)
-    private String symptom_name;
-
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "symptom", cascade = CascadeType.ALL)
     @Builder.Default
     private List<FeverReportSymptom> feverReportSymptoms = new ArrayList<>();

--- a/src/test/java/final_project/momeasy/domain/fever_report/repository/FeverReportRepositoryTest.java
+++ b/src/test/java/final_project/momeasy/domain/fever_report/repository/FeverReportRepositoryTest.java
@@ -102,9 +102,8 @@ class FeverReportRepositoryTest {
     void findAllByOrderByIdDesc_shouldReturnFeverReportsInDescendingOrder() {
         // given
         PageRequest pageRequest = PageRequest.of(0, 2); // 첫 페이지, 페이지당 2개 항목
-
         // when
-        Slice<FeverReport> reports = feverReportRepository.findAllByOrderByIdDesc(pageRequest);
+        Slice<FeverReport> reports = feverReportRepository.findAllByChildIdOrderByIdDesc(child.getId(), pageRequest);
 
         // then
         assertThat(reports.getContent()).hasSize(2);

--- a/src/test/java/final_project/momeasy/domain/symptom/repository/SymptomRepositoryTest.java
+++ b/src/test/java/final_project/momeasy/domain/symptom/repository/SymptomRepositoryTest.java
@@ -59,17 +59,14 @@ class SymptomRepositoryTest {
         // 증상 생성
         symptom1 = Symptom.builder()
                 .symptom(SymptomType.발열)
-                .symptom_name("고열")
                 .build();
 
         symptom2 = Symptom.builder()
                 .symptom(SymptomType.기침)
-                .symptom_name("마른기침")
                 .build();
 
         symptom3 = Symptom.builder()
                 .symptom(SymptomType.콧물)
-                .symptom_name("맑은 콧물")
                 .build();
 
         // 증상과 발열 보고서 연결


### PR DESCRIPTION
## 🔘Part

- [x] DTO 생성, converter 생성
- [x] controller 생성
- [x] service 생성
- [x] repository 기능 추가 
- [x] 테스트 완료
- [x] symptom, string symptom_name 삭제 

  <br/>

## 🔎 작업 내용

발열 리포트 DTO, converter, service, controller 구현
발열 리포트 조회, 삭제, 생성 구현
단일 조회 함수 repository에 추가

  <br/>

## 이미지 첨부
symptom erd
![image](https://github.com/user-attachments/assets/929d9015-de7c-4ad3-b8af-e917ff874cd3)

symptom.java
![image](https://github.com/user-attachments/assets/4688a7a9-accf-4b69-99ff-f74fc03dba5c)

기존에 Symptom에 있던 string symptom_name은 증상 정보 출력을 위한 속성임
 SymptomType symptom을 통해 증상 정보를 출력할 수 있어 symptom_name 속성을 삭제했음
<br/>


## ➕ 이슈 링크

- [server #15 ](https://github.com/SMU-25/server/issues/15#issue-3068803261)

<br/>
