### PR TITLE
:bug: [Fix] 발열 리포트 생성 return 값 할당

### DIFF
--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -20,6 +20,7 @@ public class FeverReportConverter {
         return FeverReport.builder()
                 .outing(feverReportCreateDTO.getOuting())
                 .special(special)
+                .etc_symptom(feverReportCreateDTO.getEtc_symptom())
                 .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
@@ -72,6 +72,6 @@ public class FeverReportServiceImpl implements FeverReportService {
         if(feverReport == null) {
             throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
         }
-        return null;
+        return FeverReportConverter.toFeverReportViewDTO(feverReport);
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] FeverReportServiceImpl.java 
- [x] FeverReportConverter.java 

  <br/>

## 🔎 작업 내용

 발열 리포트 생성할 때 생성한 리포트 return
etc_symptom 값 null bug 해결

  <br/>

## 이미지 첨부
입력값
![image](https://github.com/user-attachments/assets/2b1a0bda-3882-4743-aacd-e652a695e42d)

결과값
![image](https://github.com/user-attachments/assets/fb4fdf95-9a8d-4300-8736-6f7fa039274e)

<br/>


## ➕ 이슈 링크

- [server #27 ](https://github.com/SMU-25/server/issues/27#issue-3094176061)

<br/>
