### PR TITLE
✨ [Feat] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,16 @@ dependencies {
 	// Springdoc OpenAPI (Swagger)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+	// OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// Webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Netty
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/final_project/momeasy/common/enums/Gender.java
+++ b/src/main/java/final_project/momeasy/common/enums/Gender.java
@@ -6,8 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Gender {
-    GIRL("여자"),
-    BOY("남자");
-
-    private final String gender;
+    FEMALE, MALE
 }

--- a/src/main/java/final_project/momeasy/domain/parent/controller/ParentController.java
+++ b/src/main/java/final_project/momeasy/domain/parent/controller/ParentController.java
@@ -1,25 +1,10 @@
 package final_project.momeasy.domain.parent.controller;
 
-import final_project.momeasy.domain.parent.dto.request.ParentRequestDTO;
-import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
-import final_project.momeasy.domain.parent.service.command.ParentCommandService;
-import final_project.momeasy.global.apiPayload.CustomResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class ParentController {
 
-    private final ParentCommandService parentCommandService;
-
-    @PostMapping("/signup")
-    public CustomResponse<ParentResponseDTO.ParentCreateResponseDTO> localSignUp(
-            @RequestBody ParentRequestDTO.ParentCreateRequestDTO createDTO) {
-        return CustomResponse.onSuccess(HttpStatus.CREATED, parentCommandService.createParent(createDTO));
-    }
 }

--- a/src/main/java/final_project/momeasy/domain/parent/converter/ParentConverter.java
+++ b/src/main/java/final_project/momeasy/domain/parent/converter/ParentConverter.java
@@ -4,6 +4,7 @@ import final_project.momeasy.common.enums.Role;
 import final_project.momeasy.domain.parent.dto.request.ParentRequestDTO;
 import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
 import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.global.auth.dto.ParentProfile;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,6 +31,19 @@ public class ParentConverter {
         return ParentResponseDTO.ParentCreateResponseDTO.builder()
                 .id(parent.getId())
                 .createdAt(parent.getCreatedAt())
+                .build();
+    }
+
+    public static Parent toParentFromProfile(ParentProfile profile) {
+        return Parent.builder()
+                .name(profile.getName())
+                .email(profile.getEmail())
+                .password("")
+                .gender(profile.getGender())
+                .birthdate(profile.getBirthdate())
+                .profileImage(profile.getProfileImageUrl())
+                .role(Role.USER)
+                .socialType(profile.getSocialType())
                 .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
+++ b/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
@@ -39,6 +39,8 @@ public class Parent extends BaseEntity {
     @Column(nullable = false)
     private LocalDate birthdate;
 
+    private String profileImage;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;

--- a/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
@@ -9,19 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ParentErrorCode implements BaseErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "PARENT400", "필수 동의사항에 모두 동의해야 회원가입이 가능합니다."),
-    OAUTH_TOKEN_FAIL(HttpStatus.BAD_REQUEST, "PARENT400_1", "토큰 변환 실패"),
-    OAUTH_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "PARENT400_2", "카카오 사용자 정보 조회 실패"),
-    OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "PARENT400_3", "이메일 정보를 찾을 수 없습니다."),
-    OAUTH_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "PARENT400_4", "로그인에 실패했습니다."),
-    LOGIN_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PARENT400_5", "해당 LoginID가 이미 존재합니다."),
-    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "PARENT401_1", "비밀번호가 일치하지 않습니다."),
-    WRONG_ID(HttpStatus.UNAUTHORIZED, "PARENT401_2", "아이디가 일치하지 않습니다."),
-    WRONG_CODE(HttpStatus.UNAUTHORIZED, "PARENT401_3", "인증번호가 일치하지 않습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "PARENT401_4", "회원 정보를 수정/삭제할 권한이 없습니다."),
-    SOCIAL_USER_CANNOT_LOGIN(HttpStatus.UNAUTHORIZED, "PARENT401_5", "소셜 로그인 사용자는 로컬 로그인할 수 없습니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT404", "회원을 찾을 수 없습니다."),
+    LOGIN_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PARENT400_1", "해당 LoginID가 이미 존재합니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "PARENT409_1", "이미 사용 중인 이메일입니다."),
-    DUPLICATE_ID(HttpStatus.CONFLICT, "PARENT409_2", "이미 사용중인 아이디입니다.");
+    DUPLICATE_ID(HttpStatus.CONFLICT, "PARENT409_2", "이미 사용 중인 아이디입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT404", "회원을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
@@ -9,14 +9,19 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ParentErrorCode implements BaseErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "PARENT400", "필수 동의사항에 모두 동의해야 회원가입이 가능합니다."),
+    OAUTH_TOKEN_FAIL(HttpStatus.BAD_REQUEST, "PARENT400_1", "토큰 변환 실패"),
+    OAUTH_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "PARENT400_2", "카카오 사용자 정보 조회 실패"),
+    OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "PARENT400_3", "이메일 정보를 찾을 수 없습니다."),
+    OAUTH_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "PARENT400_4", "로그인에 실패했습니다."),
+    LOGIN_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PARENT400_5", "해당 LoginID가 이미 존재합니다."),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "PARENT401_1", "비밀번호가 일치하지 않습니다."),
-    WROND_ID(HttpStatus.UNAUTHORIZED, "PARENT401_2", "아이디가 일치하지 않습니다."),
-    WROND_CODE(HttpStatus.UNAUTHORIZED, "PARENT401_3", "인증번호가 일치하지 않습니다."),
+    WRONG_ID(HttpStatus.UNAUTHORIZED, "PARENT401_2", "아이디가 일치하지 않습니다."),
+    WRONG_CODE(HttpStatus.UNAUTHORIZED, "PARENT401_3", "인증번호가 일치하지 않습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "PARENT401_4", "회원 정보를 수정/삭제할 권한이 없습니다."),
+    SOCIAL_USER_CANNOT_LOGIN(HttpStatus.UNAUTHORIZED, "PARENT401_5", "소셜 로그인 사용자는 로컬 로그인할 수 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT404", "회원을 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "PARENT409_1", "이미 사용 중인 이메일입니다."),
     DUPLICATE_ID(HttpStatus.CONFLICT, "PARENT409_2", "이미 사용중인 아이디입니다.");
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
+++ b/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
@@ -1,8 +1,13 @@
 package final_project.momeasy.global.auth.controller;
 
+import final_project.momeasy.domain.parent.dto.request.ParentRequestDTO;
+import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
+import final_project.momeasy.domain.parent.service.command.ParentCommandService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
 import final_project.momeasy.global.security.dto.request.LoginRequestDTO;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,8 +15,17 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
+    private final ParentCommandService parentCommandService;
+
+    @PostMapping("/signup")
+    public CustomResponse<ParentResponseDTO.ParentCreateResponseDTO> localSignUp(
+            @RequestBody ParentRequestDTO.ParentCreateRequestDTO createDTO) {
+        return CustomResponse.onSuccess(HttpStatus.CREATED, parentCommandService.createParent(createDTO));
+    }
 
     // Swagger test용 dummy controller
     @PostMapping("/login")

--- a/src/main/java/final_project/momeasy/global/auth/dto/OAuthAttributes.java
+++ b/src/main/java/final_project/momeasy/global/auth/dto/OAuthAttributes.java
@@ -1,0 +1,65 @@
+package final_project.momeasy.global.auth.dto;
+
+import final_project.momeasy.common.enums.Gender;
+import final_project.momeasy.common.enums.SocialType;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+public enum OAuthAttributes {
+
+    KAKAO("kakao", attributes -> {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String name = (String) kakaoAccount.get("name");
+        String email = (String) kakaoAccount.get("email");
+        String genderStr = (String) kakaoAccount.get("gender");
+        String profileImageUrl = (String) kakaoAccount.get("profile_image_url");
+        String birthYear = (String) kakaoAccount.get("birthyear");
+        String birthDay = (String) kakaoAccount.get("birthday");
+
+        // 생년월일
+        LocalDate birthdate = null;
+        if (birthYear != null && birthDay != null && birthDay.length() == 4) {
+            try {
+                String full = birthYear + "-" + birthDay.substring(0, 2) + "-" + birthDay.substring(2, 4);
+                birthdate = LocalDate.parse(full, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            } catch (Exception ignored) {
+            }
+        }
+
+        // 성별 변환
+        Gender gender = null;
+        if ("male".equalsIgnoreCase(genderStr)) {
+            gender = Gender.MALE;
+        } else if ("female".equalsIgnoreCase(genderStr)) {
+            gender = Gender.FEMALE;
+        }
+
+        return ParentProfile.builder()
+                .name(name)
+                .email(email)
+                .profileImageUrl(profileImageUrl)
+                .gender(gender)
+                .birthdate(birthdate)
+                .socialType(SocialType.KAKAO)
+                .build();
+    });
+
+    private final String registrationId;
+    private final Function<Map<String, Object>, ParentProfile> userProfileFactory;
+
+    public static ParentProfile extract(String registrationId, Map<String, Object> attributes) {
+        return Arrays.stream(values())
+                .filter(provider -> registrationId.equals(provider.registrationId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth Provider: " + registrationId))
+                .userProfileFactory.apply(attributes);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/auth/dto/ParentProfile.java
+++ b/src/main/java/final_project/momeasy/global/auth/dto/ParentProfile.java
@@ -1,0 +1,28 @@
+package final_project.momeasy.global.auth.dto;
+
+import final_project.momeasy.common.enums.Gender;
+import final_project.momeasy.common.enums.SocialType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ParentProfile {
+    private String name;
+
+    private String email;
+
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private LocalDate birthdate;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+}

--- a/src/main/java/final_project/momeasy/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/auth/exception/AuthErrorCode.java
@@ -1,0 +1,29 @@
+package final_project.momeasy.global.auth.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+    WRONG_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH401", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401_1", "비밀번호가 일치하지 않습니다."),
+    WRONG_ID(HttpStatus.UNAUTHORIZED, "AUTH401_2", "아이디가 일치하지 않습니다."),
+    WRONG_CODE(HttpStatus.UNAUTHORIZED, "AUTH401_3", "인증번호가 일치하지 않습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH401_4", "접근 권한이 없습니다."),
+    SOCIAL_USER_CANNOT_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH401_5", "소셜 로그인 사용자는 로컬 로그인할 수 없습니다."),
+    OAUTH_TOKEN_FAIL(HttpStatus.BAD_REQUEST, "AUTH400_1", "소셜 토큰 변환에 실패했습니다."),
+    OAUTH_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "AUTH400_2", "소셜 사용자 정보 조회에 실패했습니다."),
+    OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH400_3", "이메일 정보를 찾을 수 없습니다."),
+    OAUTH_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "AUTH400_4", "로그인에 실패했습니다."),
+    ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, "AUTH403", "계정이 비활성화 되었습니다."),
+    ACCOUNT_LOCKED(HttpStatus.LOCKED, "AUTH423", "계정이 잠금 상태입니다."),
+    LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500", "인증에 실패했습니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/global/auth/exception/AuthException.java
+++ b/src/main/java/final_project/momeasy/global/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.global.auth.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class AuthException extends CustomException {
+    public AuthException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/auth/service/CustomOAuthUserService.java
+++ b/src/main/java/final_project/momeasy/global/auth/service/CustomOAuthUserService.java
@@ -1,0 +1,68 @@
+package final_project.momeasy.global.auth.service;
+
+import final_project.momeasy.common.enums.Role;
+import final_project.momeasy.domain.parent.converter.ParentConverter;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.parent.repository.ParentRepository;
+import final_project.momeasy.global.auth.dto.OAuthAttributes;
+import final_project.momeasy.global.auth.dto.ParentProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuthUserService extends DefaultOAuth2UserService {
+
+    private final ParentRepository parentRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        // 1. 기본 서비스로 사용자 정보 요청
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("[CustomOAuthUserService] OAuth2User attributes: {}", oAuth2User.getAttributes());
+
+
+        // 2. registrationId 확인 (어떤 플랫폼에서 로그인 했는지)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("[CustomOAuthUserService] 로그인 요청된 소셜 플랫폼: {}", registrationId);
+
+        // 3. 사용자 정보 파싱
+        Map<String, Object> attributes= oAuth2User.getAttributes();
+        ParentProfile profile = OAuthAttributes.extract(registrationId, attributes);
+        log.info("[CustomOAuthUserService] 파싱된 사용자 프로필: {}", profile);
+
+
+        // 4. DB 저장 or 조회
+        Parent parent = saveOrUpdate(profile);
+
+        // 5. 인증 객체 반환 (USER) 권한 부여
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(Role.USER.name())),
+                attributes,
+                "id"
+        );
+    }
+
+    private Parent saveOrUpdate(ParentProfile profile) {
+        log.info("[CustomOAuthUserService] 이메일로 사용자 조회 중: {}", profile.getEmail());
+
+        return parentRepository.findByEmail(profile.getEmail())
+                .orElseGet(() -> {
+                    log.info("[CustomOAuthUserService] 신규 사용자입니다. 회원 가입을 진행합니다.");
+                    Parent newParent = ParentConverter.toParentFromProfile(profile);
+                    return parentRepository.save(newParent);
+                });
+    }
+}

--- a/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import final_project.momeasy.domain.parent.repository.ParentRepository;
 import final_project.momeasy.domain.token.service.TokenService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.auth.service.CustomOAuthUserService;
 import final_project.momeasy.global.security.filter.CustomLoginFilter;
 import final_project.momeasy.global.security.filter.JwtAuthorizationFilter;
 import final_project.momeasy.global.security.handler.CustomLogoutHandler;
 import final_project.momeasy.global.security.handler.JwtAccessDeniedHandler;
 import final_project.momeasy.global.security.handler.JwtAuthenticationEntryPoint;
+import final_project.momeasy.global.security.handler.OAuth2LoginSuccessHandler;
 import final_project.momeasy.global.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -45,6 +47,11 @@ public class SecurityConfig {
     // 로그아웃 Handler
     private final CustomLogoutHandler logoutHandler;
 
+    private final CustomOAuthUserService customOAuthUserService;
+
+    // OAuth2 Handler
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -67,7 +74,9 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/swagger-resources/**",
             "/signup",
-            "/auth/login"
+            "/auth/login",
+            "/oauth2/**",
+            "/login/**"
     };
 
     @Bean
@@ -97,6 +106,14 @@ public class SecurityConfig {
                 .exceptionHandling(handler -> handler
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
+                // oauth2 로그인
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuthUserService)
+                        )
+                        .successHandler(oAuth2LoginSuccessHandler)
+                )
 
                 // 로그아웃
                 .logout(logout -> logout

--- a/src/main/java/final_project/momeasy/global/security/CustomUserDetailsService.java
+++ b/src/main/java/final_project/momeasy/global/security/CustomUserDetailsService.java
@@ -5,6 +5,7 @@ import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.parent.exception.ParentErrorCode;
 import final_project.momeasy.domain.parent.exception.ParentException;
 import final_project.momeasy.domain.parent.repository.ParentRepository;
+import final_project.momeasy.global.auth.exception.AuthErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -30,7 +31,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         // 소셜 로그인 유저일 경우 로그인 불가 예외
         if (parent.getSocialType() != SocialType.LOCAL) {
-            throw new AuthenticationServiceException(ParentErrorCode.SOCIAL_USER_CANNOT_LOGIN.getMessage());
+            throw new AuthenticationServiceException(AuthErrorCode.SOCIAL_USER_CANNOT_LOGIN.getMessage());
         }
 
         return new CustomUserDetails(parent);

--- a/src/main/java/final_project/momeasy/global/security/CustomUserDetailsService.java
+++ b/src/main/java/final_project/momeasy/global/security/CustomUserDetailsService.java
@@ -1,11 +1,13 @@
 package final_project.momeasy.global.security;
 
+import final_project.momeasy.common.enums.SocialType;
 import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.parent.exception.ParentErrorCode;
 import final_project.momeasy.domain.parent.exception.ParentException;
 import final_project.momeasy.domain.parent.repository.ParentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -25,6 +27,11 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         Parent parent = parentRepository.findByEmail(email)
                 .orElseThrow(() -> new ParentException(ParentErrorCode.NOT_FOUND));
+
+        // 소셜 로그인 유저일 경우 로그인 불가 예외
+        if (parent.getSocialType() != SocialType.LOCAL) {
+            throw new AuthenticationServiceException(ParentErrorCode.SOCIAL_USER_CANNOT_LOGIN.getMessage());
+        }
 
         return new CustomUserDetails(parent);
     }

--- a/src/main/java/final_project/momeasy/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/final_project/momeasy/global/security/filter/CustomLoginFilter.java
@@ -119,8 +119,13 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             errorCode = "LOGIN404";
             errorMessage = "계정을 찾을 수 없습니다.";
         } else if (failed instanceof AuthenticationServiceException) {
-            errorCode = "LOGIN400";
-            errorMessage = "RequestBody 파싱 중 오류가 발생했습니다.";
+            if (failed.getMessage().contains("소셜 로그인")) {
+                errorCode = "LOGIN401_SOCIAL";
+                errorMessage = failed.getMessage();
+            } else {
+                errorCode = "LOGIN400";
+                errorMessage = "RequestBody 파싱 중 오류가 발생했습니다.";
+            }
         } else {
             errorCode = "LOGIN500";
             errorMessage = "인증에 실패했습니다.";

--- a/src/main/java/final_project/momeasy/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/final_project/momeasy/global/security/filter/CustomLoginFilter.java
@@ -3,6 +3,7 @@ package final_project.momeasy.global.security.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import final_project.momeasy.domain.token.service.TokenService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.auth.exception.AuthErrorCode;
 import final_project.momeasy.global.security.CustomUserDetails;
 import final_project.momeasy.global.security.dto.request.LoginRequestDTO;
 import final_project.momeasy.global.security.dto.response.LoginResponseDTO;
@@ -103,37 +104,29 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         log.info("[ LoginFilter ] 로그인에 실패했습니다.");
 
-        String errorCode;
-        String errorMessage;
+        AuthErrorCode authError;
 
         if (failed instanceof BadCredentialsException) {
-            errorCode = "LOGIN401";
-            errorMessage = "잘못된 정보입니다.";
+            authError = AuthErrorCode.WRONG_CREDENTIALS;
         } else if (failed instanceof LockedException) {
-            errorCode = "LOGIN423";
-            errorMessage = "계정이 잠금 상태입니다.";
+            authError = AuthErrorCode.ACCOUNT_LOCKED;
         } else if (failed instanceof DisabledException) {
-            errorCode = "LOGIN403";
-            errorMessage = "계정이 비활성화 되었습니다.";
+            authError = AuthErrorCode.ACCOUNT_DISABLED;
         } else if (failed instanceof UsernameNotFoundException) {
-            errorCode = "LOGIN404";
-            errorMessage = "계정을 찾을 수 없습니다.";
+            authError = AuthErrorCode.OAUTH_EMAIL_NOT_FOUND;
         } else if (failed instanceof AuthenticationServiceException) {
             if (failed.getMessage().contains("소셜 로그인")) {
-                errorCode = "LOGIN401_SOCIAL";
-                errorMessage = failed.getMessage();
+                authError = AuthErrorCode.SOCIAL_USER_CANNOT_LOGIN;
             } else {
-                errorCode = "LOGIN400";
-                errorMessage = "RequestBody 파싱 중 오류가 발생했습니다.";
+                authError = AuthErrorCode.OAUTH_TOKEN_FAIL;
             }
         } else {
-            errorCode = "LOGIN500";
-            errorMessage = "인증에 실패했습니다.";
+            authError = AuthErrorCode.LOGIN_FAILED;
         }
 
         // Custom Response 생성 (data는 null로 설정)
         CustomResponse<Void> customResponse
-                = CustomResponse.onFailure(HttpStatus.UNAUTHORIZED, errorCode, errorMessage, null);
+                = CustomResponse.onFailure(authError.getStatus(), authError.getCode(), authError.getMessage(), null);
 
         ResponseUtil.writeJsonResponse(response, customResponse, HttpStatus.UNAUTHORIZED);
     }

--- a/src/main/java/final_project/momeasy/global/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/final_project/momeasy/global/security/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,79 @@
+package final_project.momeasy.global.security.handler;
+
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.parent.exception.ParentErrorCode;
+import final_project.momeasy.domain.parent.exception.ParentException;
+import final_project.momeasy.domain.parent.repository.ParentRepository;
+import final_project.momeasy.domain.token.service.TokenService;
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.auth.dto.OAuthAttributes;
+import final_project.momeasy.global.auth.dto.ParentProfile;
+import final_project.momeasy.global.security.CustomUserDetails;
+import final_project.momeasy.global.security.dto.response.LoginResponseDTO;
+import final_project.momeasy.global.security.jwt.JwtUtil;
+import final_project.momeasy.global.util.CookieUtil;
+import final_project.momeasy.global.util.ResponseUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final ParentRepository parentRepository;
+    private final TokenService tokenService;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) throws IOException, ServletException {
+
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+        String registrationId = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
+
+        ParentProfile profile = OAuthAttributes.extract(registrationId, oAuth2User.getAttributes());
+
+        String email = profile.getEmail();
+        log.info("[ OAuth2LoginSuccessHandler ] email: {}", email);
+
+        Parent parent = parentRepository.findByEmail(email)
+                .orElseThrow(() -> new ParentException(ParentErrorCode.NOT_FOUND));
+
+        CustomUserDetails userDetails = new CustomUserDetails(parent);
+
+        String accessToken = jwtUtil.generateJwtAccessToken(userDetails);
+        String refreshToken = jwtUtil.generateRefreshToken(userDetails);
+
+        // refresh token DB에 저장
+        tokenService.saveOrUpdate(userDetails.getUsername(), refreshToken);
+
+        // refresh token은 쿠키로 전달
+        CookieUtil.addRefreshTokenToCookie(response, refreshToken);
+
+        // Client에게 줄 Response build
+        LoginResponseDTO loginResponse = LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .build();
+
+        // Custom Response 작성
+        CustomResponse<LoginResponseDTO> customResponse
+                = CustomResponse.onSuccess(loginResponse);
+
+        ResponseUtil.writeJsonResponse(response, customResponse, HttpStatus.OK);
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,29 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            authorization-grant-type: authorization_code
+            client-id: ${KAKAO_API_KEY}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-authentication-method: client_secret_post
+            scope:
+              - name
+              - account_email
+              - gender
+              - birthday
+              - birthyear
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 jwt:
   secretKey: ${SECRET_KEY}
   token:


### PR DESCRIPTION
## 🔘Part

- [x] Kakao Login

  <br/>
## ➕ 이슈 링크

- #36 

<br/>

## 🔎 작업 내용

OAuth2 소셜 로그인 구현
- `CustomOAuthUserService`: OAuth2 인증 후 사용자 정보 받아오기 b94befb0cc9afef11b3ffa7c673c4cbbdf30c340
- `OAuth2LoginSuccessHandler` 소셜 로그인 성공 시 JWT 발급 및 응답 처리 78a67f95eedfbee2e170067dacf1f38f0d37ad82
- 소셜 계정(카카오, 구글, 네이버 등)의 로컬 로그인은 차단 49f86ea79a8fb5ba51990b981a6e345ff5fceb24
  <br/>

## 이미지 첨부
소셜 계정이 회원가입할 때 password를 어떻게 할 지 고민하다가 그냥 빈 문자열을 넘기거덩요 .. 그래서 로컬 로그인 엔드포인트로 로그인 시도 시 로그인이 불가능하게 설정했습니다.. 이래도 될까요 ? 😹😹
<img alt="image" src="https://github.com/user-attachments/assets/64cd5b56-9ad1-43c9-8fcc-e56a5d15e4fb" width="50%" height="50%"/>
카카오 로그인 하면 아래처럼 토큰 잘 나옵니당
<img alt="image" src="https://github.com/user-attachments/assets/3f428cae-7a07-4bf1-8a66-553b2490eafe" width="50%" height="50%"/>
우리 서비스가 여러 가지 기타 정보도 다 불러와야 해서 테스트 앱으로 만들어서 동의항목 설정했습니다 .. 테스트 앱으로 만들면 동의항목이 다 설정이 되더군요 ..
<img alt="image" src="https://github.com/user-attachments/assets/4707a8d5-ac3a-4d9e-b5a9-758d7057f039" width="50%" height="50%"/>


<br/>

