### PR TITLE
🐛 [FIX] JwtAuthorizationFilter 필터 체인 누락으로 요청 미처리 현상

### DIFF
--- a/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/swagger-resources/**",
-            "/signup",
+            "/auth/signup",
             "/auth/login",
             "/oauth2/**",
             "/login/**"

--- a/src/main/java/final_project/momeasy/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/final_project/momeasy/global/security/filter/JwtAuthorizationFilter.java
@@ -69,7 +69,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             ResponseUtil.writeJsonResponse(response, errorResponse, HttpStatus.UNAUTHORIZED);
         }
-
+        filterChain.doFilter(request, response);
     }
 
 


### PR DESCRIPTION
## 🔘Part

- [x] 요청 미처리 현상 해결

  <br/>


## ➕ 이슈 링크

- #42 

<br/>


## 🔎 작업 내용
**문제 설명**
: `JwtAuthorizationFilter`에서 인증은 잘 됐는데,  
`try-catch` 문 이후에 `filterChain.doFilter(request, response);` 호출이 누락되어
요청이 컨트롤러까지 전달되지 않는... 😿 문제가 있었습니다.
그로 인해 `@AuthenticationPrincipal`로 유저 정보를 받아야 하는 API는 응답이 아예 안 오거나,
허용되지 않은 URL도 필터가 끝나버려서 응답이 빈 채로 넘어오는 등의 문제가 발생 .. 🚨🚨

- [x] `JwtAuthorizationFilter` 내부 `doFilterInternal()`에서 `filterChain.doFilter()` 호출 위치 수정
- [x] `try-catch` 문 밖으로 호출을 옮겨, 모든 경우에 필터 체인이 정상적으로 연결되도록 변경
  <br/>

다음부터는 꼼꼼히 확인하고 pr 올리겠습니닼 😭😭

