### PR TITLE
:hammer: [Refactor] 홈캠, 발열 리포트, 온습도 기록, 체온 기록 created_at 변경

### DIFF
--- a/src/main/java/final_project/momeasy/domain/fever_record/converter/FeverRecordConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/converter/FeverRecordConverter.java
@@ -16,6 +16,7 @@ public class FeverRecordConverter {
     public static FeverRecordResponseDTO.FeverRecordViewDTO toFeverRecordResponseDTO(FeverRecord feverRecord) {
         return FeverRecordResponseDTO.FeverRecordViewDTO.builder()
                 .fever(feverRecord.getFever())
+                .createdAt(feverRecord.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_record/dto/FeverRecordResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/dto/FeverRecordResponseDTO.java
@@ -3,10 +3,13 @@ package final_project.momeasy.domain.fever_record.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 public class FeverRecordResponseDTO {
     @Getter
     @Builder
     public static class FeverRecordViewDTO{
         private float fever;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -13,6 +13,7 @@ public class FeverReportConverter {
                 .special(feverReport.getSpecial())
                 .etc_symptom(feverReport.getEtc_symptom())
                 .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom -> FeverReportSymptom.getSymptom().getSymptom()).toList())
+                .createdAt(feverReport.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
@@ -4,6 +4,7 @@ import final_project.momeasy.common.enums.SymptomType;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class FeverReportResponseDTO {
@@ -17,5 +18,7 @@ public class FeverReportResponseDTO {
         private String outing;
 
         private String special;
+
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/final_project/momeasy/domain/home_cam/converter/HomecamConverter.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/converter/HomecamConverter.java
@@ -10,7 +10,7 @@ public class HomecamConverter {
         return HomecamResponseDTO.HomecamDTO.builder()
                 .name(homecam.getName())
                 .place(homecam.getPlace())
-                .date(homecam.getDate())
+                .createdAt(homecam.getCreatedAt())
                 .build();
     }
 
@@ -25,7 +25,6 @@ public class HomecamConverter {
                 .name(homecamRegisterDTO.getName())
                 .serial_num(homecamRegisterDTO.getSerial_num())
                 .place(homecamRegisterDTO.getPlace())
-                .date(homecamRegisterDTO.getDate())
                 .parent(parent)
                 .build();
     }

--- a/src/main/java/final_project/momeasy/domain/home_cam/dto/HomecamRequestDTO.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/dto/HomecamRequestDTO.java
@@ -20,9 +20,5 @@ public class HomecamRequestDTO {
         @NotBlank(message = "설치 장소는 필수 입력 값입니다.")
         @JsonProperty("place")
         private String place;
-
-        @NotBlank(message = "설치 날짜는 필수 입력 값입니다.")
-        @JsonProperty("date")
-        private String date;
     }
 }

--- a/src/main/java/final_project/momeasy/domain/home_cam/dto/HomecamResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/dto/HomecamResponseDTO.java
@@ -2,13 +2,16 @@ package final_project.momeasy.domain.home_cam.dto;
 
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public class HomecamResponseDTO {
     @Getter
     @Builder
     public static class HomecamDTO {
         private String name;
         private String place;
-        private String date;
+        private LocalDateTime createdAt;
     }
 
     @Getter

--- a/src/main/java/final_project/momeasy/domain/home_cam/entity/Homecam.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/entity/Homecam.java
@@ -2,15 +2,18 @@ package final_project.momeasy.domain.home_cam.entity;
 
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Homecam {
+public class Homecam extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -20,8 +23,6 @@ public class Homecam {
     private String serial_num;
 
     private String place;
-
-    private String date;
 
     private String video_url;
 

--- a/src/main/java/final_project/momeasy/domain/room_condition/converter/RoomConditionConverter.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/converter/RoomConditionConverter.java
@@ -10,6 +10,7 @@ public class RoomConditionConverter {
         return RoomConditionResponseDTO.RoomConditionViewDTO.builder()
                 .temperature(roomCondition.getTemperature())
                 .humidity(roomCondition.getHumidity())
+                .createdAt(roomCondition.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/final_project/momeasy/domain/room_condition/dto/RoomConditionResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/dto/RoomConditionResponseDTO.java
@@ -3,11 +3,14 @@ package final_project.momeasy.domain.room_condition.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 public class RoomConditionResponseDTO {
     @Getter
     @Builder
     public static class RoomConditionViewDTO {
         private float temperature;
         private float humidity;
+        private LocalDateTime createdAt;
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x]  홈캠 BaseEntity의 created_at 사용
- [x]  발열 리포트, 온습도 기록, 체온 기록 응답 dto에 생성 날짜 추가

  <br/>

## ➕ 이슈 링크

- #52 

<br/>
## 🔎 작업 내용

- 홈캠 BaseEntity의 created_at 사용  8af7f06954fa63685f6a52946c20a873285d4412
- 홈캠 응답 dto에 생성 날짜 추가 8e07a3f916b031c16ce62b0eb46cc7033ec6bb9f
- 발열 리포트, 온습도 기록, 체온 기록 응답 dto에 생성 날짜 추가 77ec692379e7340a98e3744d766a2398a0a54395


  <br/>

## 이미지 첨부
-- 
<br/>
