### PR TITLE
✨ [FEAT] Scheduler 성능 향상

### DIFF
--- a/src/main/java/final_project/momeasy/domain/child/repository/ChildRepository.java
+++ b/src/main/java/final_project/momeasy/domain/child/repository/ChildRepository.java
@@ -13,4 +13,7 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
 
     @Query("SELECT c FROM Child c JOIN FETCH ParentChild pc ON c.id = pc.child.id WHERE pc.parent.id = :parentId")
     List<Child> findByParentId(@Param("parentId") Long parentId);
+
+    @Query("SELECT c FROM Child c JOIN FETCH c.homecam WHERE c.homecam IS NOT NULL")
+    List<Child> findByHomecamIsNotNull();
 }

--- a/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordBulkRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordBulkRepository.java
@@ -1,0 +1,43 @@
+package final_project.momeasy.domain.fever_record.repository;
+
+import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class FeverRecordBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<FeverRecord> FeverRecords) {
+        String sql = "INSERT INTO fever_record (child_id, fever, created_at) VALUES (?,?,?)";
+        Timestamp now = Timestamp.valueOf(LocalDateTime.now());
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException{
+                FeverRecord feverRecord = FeverRecords.get(i);
+                ps.setLong(1,feverRecord.getChild().getId());
+                ps.setFloat(2,feverRecord.getFever());
+                ps.setTimestamp(3, now);
+            }
+            @Override
+            public int getBatchSize() {
+                return FeverRecords.size();
+            }
+        });
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/service/FeverRecordService.java
@@ -3,8 +3,8 @@ package final_project.momeasy.domain.fever_record.service;
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.child.repository.ChildRepository;
 import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+import final_project.momeasy.domain.fever_record.repository.FeverRecordBulkRepository;
 import final_project.momeasy.domain.fever_record.repository.FeverRecordRepository;
-import final_project.momeasy.domain.home_cam.repository.HomecamRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -21,22 +22,23 @@ import java.util.List;
 public class FeverRecordService {
     private final FeverRecordRepository feverRecordRepository;
     private final ChildRepository childRepository;
-    private final HomecamRepository homecamRepository;
+    private final FeverRecordBulkRepository feverRecordBulkRepository;
 
     // for문에 센서로 데이터 입력 받아야함
     @Scheduled(cron = "0 * * * * *")
     public void createFeverRecord(){
         log.info("Starting scheduled create Fever Record");
-        List<Child> childList = childRepository.findAll();
-        for(Child child : childList){
-            if(child.getHomecam()==null){continue;}
+        List<Child> childList = childRepository.findByHomecamIsNotNull();
+        List<FeverRecord> feverRecords = new ArrayList<>();
+        for (Child child : childList) {
             FeverRecord feverRecord = FeverRecord.builder()
                     .fever(36.5f)
+                    .child(child)
                     .build();
-            feverRecord.setChild(child);
-            feverRecordRepository.save(feverRecord);
-            log.info(child.getName()+" ("+feverRecord.getId()+") Fever Record created");
+            feverRecords.add(feverRecord);
         }
+        feverRecordBulkRepository.saveAll(feverRecords);
+        log.info("Ending scheduled create Fever Record");
     }
 
     @Scheduled(cron = "0 0 0 * * *")

--- a/src/main/java/final_project/momeasy/domain/room_condition/repository/RoomConditionBulkRepository.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/repository/RoomConditionBulkRepository.java
@@ -1,0 +1,42 @@
+package final_project.momeasy.domain.room_condition.repository;
+
+import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomConditionBulkRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<RoomCondition> roomConditions) {
+        String sql = "INSERT INTO room_condition (child_id, humidity,temperature, created_at) VALUES (?,?,?,?)";
+        Timestamp now = Timestamp.valueOf(LocalDateTime.now());
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                RoomCondition roomCondition = roomConditions.get(i);
+                ps.setLong(1,roomCondition.getChild().getId());
+                ps.setFloat(2,roomCondition.getHumidity());
+                ps.setFloat(3,roomCondition.getTemperature());
+                ps.setTimestamp(4, now);
+            }
+            @Override
+            public int getBatchSize() {
+                return roomConditions.size();
+            }
+        });
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionService.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionService.java
@@ -3,6 +3,7 @@ package final_project.momeasy.domain.room_condition.service;
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.child.repository.ChildRepository;
 import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+import final_project.momeasy.domain.room_condition.repository.RoomConditionBulkRepository;
 import final_project.momeasy.domain.room_condition.repository.RoomConditionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -20,22 +22,24 @@ import java.util.List;
 public class RoomConditionService {
     private final RoomConditionRepository roomConditionRepository;
     private final ChildRepository childRepository;
+    private final RoomConditionBulkRepository roomConditionBulkRepository;
 
     // // 아이에게 홈캠이 있는지 예외 처리 필요, for문에 센서로 데이터 입력 받아야함
     @Scheduled(cron = "0 * * * * *")
     public void createRoomCondition() {
         log.info("Starting scheduled create Room Condition");
-        List<Child> childList = childRepository.findAll();
+        List<Child> childList = childRepository.findByHomecamIsNotNull();
+        List<RoomCondition> roomConditions = new ArrayList<>();
         for(Child child : childList){
-            if(child.getHomecam()==null){continue;}
             RoomCondition roomCondition = RoomCondition.builder()
                     .temperature(36.5f)
                     .humidity(50.0f)
+                    .child(child)
                     .build();
-            roomCondition.setChild(child);
-            roomConditionRepository.save(roomCondition);
-            log.info(child.getName()+" ("+roomCondition.getId()+") Room Condition created");
+            roomConditions.add(roomCondition);
         }
+        roomConditionBulkRepository.saveAll(roomConditions);
+        log.info("Ending scheduled create Room Condition");
     }
 
     @Scheduled(cron = "0 0 0 * * *")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+        jdbc:
+          batch_size: 1000
+          batch_versioned_data: true
+        order_inserts: true
+        order_updates: true
 
   security:
     oauth2:


### PR DESCRIPTION
## 🔘Part

- [x] Scheduler 성능 개선

  <br/>

## ➕ 이슈 링크

- #55 

<br/>

## 🔎 작업 내용

- N+1 문제 해결 b8f115bec9b3c73e7bc60403992ea4714faac078
- Bulk Insert 도입 28dd07464c4082a93096bb6826469bbcf2dacbff

  <br/>

## 이미지 첨부 

### 성능 개선 전( 테스트 데이터 parent, child 각각 10만명, Homecam 가진 child 2만명 )

#### FeverRecord 생성 Scheduler 
![Image](https://github.com/user-attachments/assets/6ea4fbab-d6cb-4d6b-a948-cdbac679fd16)
#### 소요 시간
![Image](https://github.com/user-attachments/assets/0e4bc3f7-3026-4aa0-9b0e-caa6af26073b)
N+1문제로 인해 child.gethomecam() 실행마다 쿼리문 발생 -> for문(2만 개) 쿼리 발생
Bulk Insert가 없어 feverRecordRepository.save() 실행마다 쿼리문 발생 ->  for문(2만 개) 쿼리 발생
총 소요 시간 33초

--- 
### 성능 개선 이후
#### FeverRecord 생성 Scheduler 

![Image](https://github.com/user-attachments/assets/c1e0d50d-0c90-4c7d-964a-a148cac5c619)

####  childRepository.java 

![Image](https://github.com/user-attachments/assets/d2dd0f8a-6908-4466-8d7c-111e6087ae8c)
JOIN FETCH를 통해 N+1 문제 해결, db에서 Homacam 있는 child만 꺼냈으니 child.gethomecam() 실행 X
=> 쿼리문 2만개 -> 1개 감소

#### FeverRecordBulkRepository.java

![Image](https://github.com/user-attachments/assets/6bd23db2-146a-4984-8d65-1796c9c4017f)
Bulk Insert를 통해 INSERT INTO 1번으로 feverRecords db에 저장
=> 쿼리문 2만개 -> 1개 감소

#### 소요 시간

![Image](https://github.com/user-attachments/assets/d456f818-e221-4e7c-bbe5-cf50a0a1d3e5)

# **33초 -> 0.7초, 97.9% 의 성능 개선 완료**

<br/>

