### PR TITLE
🐛 [FIX] 회원가입 시 이메일 중복 예외 처리

### DIFF
--- a/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
@@ -24,6 +24,10 @@ public class ParentCommandServiceImpl implements ParentCommandService {
 
     @Override
     public ParentResponseDTO.ParentCreateResponseDTO createParent(ParentRequestDTO.ParentCreateRequestDTO parentCreateRequestDTO) {
+        if (parentRepository.findByEmail(parentCreateRequestDTO.getEmail()).isPresent()) {
+            throw new ParentException(ParentErrorCode.DUPLICATE_EMAIL);
+        }
+
         // DTO -> Parent
         Parent parent = ParentConverter.toParent(parentCreateRequestDTO, passwordEncoder);
 

--- a/src/main/java/final_project/momeasy/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/code/GeneralErrorCode.java
@@ -15,6 +15,8 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
     NOT_FOUND_404(HttpStatus.NOT_FOUND, "COMMON404", "요청한 자원을 찾을 수 없습니다"),
 
+    DUPLICATE_409(HttpStatus.CONFLICT, "COMMON409", "이미 존재하는 값입니다."),
+
     INTERNAL_SERVER_ERROR_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다"),
 
     // 유효성 검사

--- a/src/main/java/final_project/momeasy/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import final_project.momeasy.global.apiPayload.exception.CustomException;
 import jakarta.validation.ConstraintViolation;
 import lombok.extern.slf4j.Slf4j;
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,6 +48,17 @@ public class GlobalExceptionHandler {
         log.error("[ MethodArgumentNotValidException ]: {} ", error);
         CustomResponse<Map<String,String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(),error);
         return ResponseEntity.status(errorCode.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<CustomResponse<Map<String,String>>> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        log.error("[ DataIntegrityViolationException ]: {} ", ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.DUPLICATE_409;
+        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
+++ b/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
 import final_project.momeasy.domain.parent.service.command.ParentCommandService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
 import final_project.momeasy.global.security.dto.request.LoginRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,10 +16,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "인증 관련 API")
 public class AuthController {
 
     private final ParentCommandService parentCommandService;
 
+    @Operation(summary = "로컬 회원가입")
     @PostMapping("/signup")
     public CustomResponse<ParentResponseDTO.ParentCreateResponseDTO> localSignUp(
             @RequestBody ParentRequestDTO.ParentCreateRequestDTO createDTO) {
@@ -25,12 +29,14 @@ public class AuthController {
     }
 
     // Swagger test용 dummy controller
+    @Operation(summary = "로컬 로그인")
     @PostMapping("/login")
     public CustomResponse<?> localLogin(@RequestBody LoginRequestDTO loginDTO) {
         return null;
     }
 
     // Swagger test용 dummy controller
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public CustomResponse<?> logout() {
         return null;

--- a/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
+++ b/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthController {
 
     private final ParentCommandService parentCommandService;

--- a/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
@@ -73,8 +73,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/swagger-resources/**",
-            "/auth/signup",
-            "/auth/login",
+            "/api/auth/signup",
+            "/api/auth/login",
             "/oauth2/**",
             "/login/**"
     };


### PR DESCRIPTION
## 🔘Part

- [x] 이메일에 유니크 제약이 걸려 있는지 확인
- [x] DataIntegrityViolationException 글로벌 핸들러 로직 작성

  <br/>


## ➕ 이슈 링크

- #62 
<br/>

## 🔎 작업 내용

- Parent 엔티티에 유티크 제약 설정 → 중복 저장 시 예외 발생
- 서비스단에서 이메일 중복 여부 체크 후 중복 시 ParentException
- 추가로 GlobalExceptionHandler에서 DataIntegrityViolationException을 핸들링하는 이중 방어 적용

  <br/>

## 이미지 첨부

잘 됩니다용
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/95b82efa-0237-404d-86e8-3d2a0a41b60e" />

<br/>


