### PR TITLE
✨ [FEAT] 온도, 습도, 체온 그래프 엔티티 생성 / 발열 리포트에 그래프 기능 추가

### DIFF
--- a/src/main/java/final_project/momeasy/common/enums/DayRange.java
+++ b/src/main/java/final_project/momeasy/common/enums/DayRange.java
@@ -1,0 +1,15 @@
+package final_project.momeasy.common.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DayRange {
+    Day1("1일"),
+    Day3("3일"),
+    Day7("7일");
+
+    private final String dayrange;
+
+}

--- a/src/main/java/final_project/momeasy/common/enums/DayRange.java
+++ b/src/main/java/final_project/momeasy/common/enums/DayRange.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum DayRange {
-    Day1("1일"),
-    Day3("3일"),
-    Day7("7일");
+    DAY1("1일"),
+    DAY3("3일"),
+    DAY7("7일");
 
     private final String dayrange;
 

--- a/src/main/java/final_project/momeasy/domain/fever_graph/converter/FeverGraphConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/converter/FeverGraphConverter.java
@@ -1,0 +1,18 @@
+package final_project.momeasy.domain.fever_graph.converter;
+
+import final_project.momeasy.domain.fever_graph.dto.FeverGraphResponseDTO;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+
+public class FeverGraphConverter {
+    public static FeverGraphResponseDTO.FeverGraphCreateDTO toFeverGraphCreateDTO(FeverGraph feverGraph) {
+        return FeverGraphResponseDTO.FeverGraphCreateDTO.builder()
+                .fever(feverGraph.getFever())
+                .build();
+    }
+
+    public static FeverGraphResponseDTO.FeverGraphViewDTO toFeverGraphViewDTO(FeverGraph feverGraph) {
+        return FeverGraphResponseDTO.FeverGraphViewDTO.builder()
+                .fever(feverGraph.getFever())
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/dto/FeverGraphResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/dto/FeverGraphResponseDTO.java
@@ -1,0 +1,18 @@
+package final_project.momeasy.domain.fever_graph.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FeverGraphResponseDTO {
+    @Getter
+    @Builder
+    public static class FeverGraphCreateDTO{
+        private float fever;
+    }
+
+    @Getter
+    @Builder
+    public static class FeverGraphViewDTO{
+        private float fever;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/entity/FeverGraph.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/entity/FeverGraph.java
@@ -1,0 +1,33 @@
+package final_project.momeasy.domain.fever_graph.entity;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeverGraph extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private float fever;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayRange dayRange;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fever_report_id", nullable = false)
+    private FeverReport feverReport;
+
+    public void setFeverReport(FeverReport feverReport) {
+        this.feverReport = feverReport;
+        feverReport.getFeverGraphs().add(this);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/exception/FeverGraphErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/exception/FeverGraphErrorCode.java
@@ -1,0 +1,18 @@
+package final_project.momeasy.domain.fever_graph.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum FeverGraphErrorCode implements BaseErrorCode {
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "FEVER_GRAPH401", "체온 그래프에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "FEVER_GRAPH404", "체온 그래프을 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FEVER_GRAPH500", "체온 그래프 처리 중 서버 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/exception/FeverGraphException.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/exception/FeverGraphException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.fever_graph.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class FeverGraphException extends CustomException {
+    public FeverGraphException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/repository/FeverGraphRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/repository/FeverGraphRepository.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.fever_graph.repository;
+
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeverGraphRepository extends JpaRepository<FeverGraph, Long> {
+    List<FeverGraph> findByFeverReport(FeverReport feverreport);
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/AvgFever.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/AvgFever.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class AvgFever {
     private final FeverRecordRepository feverRecordRepository;
 
-    public float getFeverAvgBy3Hour(int t, Long childId) {
-        LocalDateTime start = LocalDate.now().atTime(t,0);
-        LocalDateTime end = (t == 21)
+    public float getFeverAvgBy3Hour(int time, Long childId) {
+        LocalDateTime start = LocalDate.now().atTime(time,0);
+        LocalDateTime end = (time == 21)
                 ?LocalDate.now().plusDays(1).atStartOfDay()
-                :LocalDate.now().atTime(t+3,0);
+                :LocalDate.now().atTime(time+3,0);
         List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
         return (float) Math.round(
                 feverRecords.stream()
@@ -28,12 +28,12 @@ public class AvgFever {
         ) / 10;
     }
 
-    public float getFeverAvgByDayAndTimeRange(int day, int t1, int t2, Long childId) {
+    public float getFeverAvgByDayAndTimeRange(int day, int time1, int time2, Long childId) {
         LocalDate now = LocalDate.now().minusDays(day);
-        LocalDateTime start = now.atTime(t1,0);
-        LocalDateTime end = (t2 == 24)
+        LocalDateTime start = now.atTime(time1,0);
+        LocalDateTime end = (time2 == 24)
                 ? now.plusDays(1).atStartOfDay()
-                : now.atTime(t2, 0);
+                : now.atTime(time2, 0);
         List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
         return (float) Math.round(
                 feverRecords.stream()

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/AvgFever.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/AvgFever.java
@@ -1,0 +1,45 @@
+package final_project.momeasy.domain.fever_graph.service;
+
+import final_project.momeasy.domain.fever_record.entity.FeverRecord;
+import final_project.momeasy.domain.fever_record.repository.FeverRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class AvgFever {
+    private final FeverRecordRepository feverRecordRepository;
+
+    public float getFeverAvgBy3Hour(int t, Long childId) {
+        LocalDateTime start = LocalDate.now().atTime(t,0);
+        LocalDateTime end = (t == 21)
+                ?LocalDate.now().plusDays(1).atStartOfDay()
+                :LocalDate.now().atTime(t+3,0);
+        List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
+        return (float) Math.round(
+                feverRecords.stream()
+                        .mapToDouble(FeverRecord::getFever)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10;
+    }
+
+    public float getFeverAvgByDayAndTimeRange(int day, int t1, int t2, Long childId) {
+        LocalDate now = LocalDate.now().minusDays(day);
+        LocalDateTime start = now.atTime(t1,0);
+        LocalDateTime end = (t2 == 24)
+                ? now.plusDays(1).atStartOfDay()
+                : now.atTime(t2, 0);
+        List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
+        return (float) Math.round(
+                feverRecords.stream()
+                        .mapToDouble(FeverRecord::getFever)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphService.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.fever_graph.service;
+
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+import final_project.momeasy.domain.parent.entity.Parent;
+
+import java.util.List;
+
+public interface FeverGraphService {
+    // service 안에서만 사용 -> entity 반환해도 괜찮음
+    List<FeverGraph> createFeverRecordGraph(Long recordId, Parent parent, Long childId);
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphServiceImpl.java
@@ -1,0 +1,59 @@
+package final_project.momeasy.domain.fever_graph.service;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+import final_project.momeasy.domain.fever_graph.repository.FeverGraphRepository;
+
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
+import final_project.momeasy.domain.fever_report.exception.FeverReportException;
+import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import final_project.momeasy.domain.parent.entity.Parent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeverGraphServiceImpl implements FeverGraphService {
+    private final FeverGraphRepository feverGraphRepository;
+    private final FeverReportRepository feverReportRepository;
+    private final AvgFever avgFever;
+
+    @Override
+    public List<FeverGraph> createFeverRecordGraph(Long recordId, Parent parent, Long childId) {
+        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+
+        List<FeverGraph> feverGraphs = new ArrayList<>();
+        // 범위 day1
+        for(int t = 0 ; t <24 ; t+=3){
+            feverGraphs.add(buildFeverGraph(feverReport, 0, DayRange.Day1,t, t, childId));
+        }
+        // 범위 day3
+        for (int d = 2; d >= 0; d--) {
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day3,0, 6,childId));   // 새벽
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day3,6, 12,childId));  // 오전
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day3,12, 24,childId)); // 오후
+        }
+        // 범위 day7
+        for(int d = 6; d>=0; d--){
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day7,0, 24,childId));
+        }
+        feverGraphRepository.saveAll(feverGraphs);
+        return feverGraphs;
+    }
+
+    private FeverGraph buildFeverGraph(FeverReport feverReport, int dayOffset, DayRange dayRange ,int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.Day1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        FeverGraph feverGraph = FeverGraph.builder()
+                .fever(avg)
+                .dayRange(dayRange)
+                .build();
+        feverGraph.setFeverReport(feverReport);
+        return feverGraph;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphServiceImpl.java
@@ -31,26 +31,26 @@ public class FeverGraphServiceImpl implements FeverGraphService {
         List<FeverGraph> feverGraphs = new ArrayList<>();
         // 범위 day1
         for(int t = 0 ; t <24 ; t+=3){
-            feverGraphs.add(buildFeverGraph(feverReport, 0, DayRange.Day1,t, t, childId));
+            feverGraphs.add(buildFeverGraph(feverReport, 0, DayRange.DAY1,t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day3,0, 6,childId));   // 새벽
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day3,6, 12,childId));  // 오전
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day3,12, 24,childId)); // 오후
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY3,0, 6,childId));   // 새벽
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY3,6, 12,childId));  // 오전
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY3,12, 24,childId)); // 오후
         }
         // 범위 day7
         for(int d = 6; d>=0; d--){
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.Day7,0, 24,childId));
+            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY7,0, 24,childId));
         }
         feverGraphRepository.saveAll(feverGraphs);
         return feverGraphs;
     }
 
     private FeverGraph buildFeverGraph(FeverReport feverReport, int dayOffset, DayRange dayRange ,int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.Day1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        float avg = dayRange == DayRange.DAY1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
         FeverGraph feverGraph = FeverGraph.builder()
-                .fever(avg)
+                .avgFever(avg)
                 .dayRange(dayRange)
                 .build();
         feverGraph.setFeverReport(feverReport);

--- a/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface FeverRecordRepository extends JpaRepository<FeverRecord, Long> {
@@ -23,4 +24,6 @@ public interface FeverRecordRepository extends JpaRepository<FeverRecord, Long> 
     @Modifying
     @Query("DELETE FROM FeverRecord fr WHERE fr.createdAt < :time") //스케줄링(@Scheduled)과 함께 사용, 7일 분량의 데이터만 저장
     void deleteByCreatedAtBefore(@Param("time") LocalDateTime time);
+
+    List<FeverRecord> findByChildIdAndCreatedAtBetween(Long childId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/controller/FeverReportController.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/controller/FeverReportController.java
@@ -23,12 +23,12 @@ public class FeverReportController {
     private final FeverReportService feverReportService;
     private final FeverReportQueryService feverReportQueryService;
 
-    @GetMapping("/{childId}/{reportId}")
+    @GetMapping("/{reportId}")
     @Operation(summary = "발열 리포트 상세 조회", description = "발열 리포트를 1개 조회합니다.")
-    public CustomResponse<FeverReportResponseDTO.FeverReportViewDTO> getFeverReport(@AuthParent Parent parent,
-        @PathVariable("childId") long childId, @PathVariable("reportId") long reportId) {
-        FeverReportResponseDTO.FeverReportViewDTO feverReportViewDTO = feverReportQueryService.getFeverReport(parent, childId, reportId);
-        return CustomResponse.onSuccess(feverReportViewDTO);
+    public CustomResponse<FeverReportResponseDTO.FeverReportDetailViewDTO> getFeverReport(@AuthParent Parent parent,
+        @PathVariable("reportId") long reportId) {
+        FeverReportResponseDTO.FeverReportDetailViewDTO feverReportDetailViewDTO = feverReportQueryService.getFeverReport(parent, reportId);
+        return CustomResponse.onSuccess(feverReportDetailViewDTO);
     }
 
     @GetMapping("/list/{childId}")
@@ -47,27 +47,27 @@ public class FeverReportController {
         return CustomResponse.onSuccess(feverReportViewDTOList);
     }
 
-    @DeleteMapping("/{childId}/{reportId}")
+    @DeleteMapping("/{reportId}")
     @Operation(summary = "발열 리포트 삭제", description = "발열 리포트를 삭제합니다.")
     public CustomResponse<String> deleteFeverReport(@AuthParent Parent parent,
-     @PathVariable("childId") long childId, @PathVariable("reportId") long reportId){
-        feverReportService.deleteFeverReport(parent,reportId,childId);
-        return CustomResponse.onSuccess(HttpStatus.NO_CONTENT,"아이 삭제 완료");
+     @PathVariable("reportId") long reportId){
+        feverReportService.deleteFeverReport(parent,reportId);
+        return CustomResponse.onSuccess(HttpStatus.NO_CONTENT,"발열 리포트 삭제 완료");
     }
 
     @PostMapping("/{childId}")
     @Operation(summary = "발열 리포트 생성", description = "발열 리포트를 생성합니다.")
-    public CustomResponse<FeverReportResponseDTO.FeverReportViewDTO> createFeverReport(@AuthParent Parent parent,
+    public CustomResponse<FeverReportResponseDTO.FeverReportCreateDTO> createFeverReport(@AuthParent Parent parent,
     @RequestBody FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, @PathVariable("childId") long childId) {
-        FeverReportResponseDTO.FeverReportViewDTO feverReportViewDTO = feverReportService.createFeverReport(parent, feverReportRequestDTO, childId);
+        FeverReportResponseDTO.FeverReportCreateDTO feverReportViewDTO = feverReportService.createFeverReport(parent, feverReportRequestDTO, childId);
         return CustomResponse.onSuccess(HttpStatus.CREATED,feverReportViewDTO);
     }
 
-    @PatchMapping("/{childId}/{reportId}")
+    @PatchMapping("/{reportId}")
     @Operation(summary = "발열 리포트 수정", description = "발열 리포트를 수정합니다.")
     public CustomResponse<String> updateFeverReport(@AuthParent Parent parent,
-   @RequestBody FeverReportRequestDTO.FeverReportUpdateDTO feverReportRequestDTO, @PathVariable("childId") long childId, @PathVariable("reportId") long reportId) {
-        feverReportService.updateFeverReport(parent,reportId,childId, feverReportRequestDTO);
-        return CustomResponse.onSuccess("아이 정보 수정 완료");
+   @RequestBody FeverReportRequestDTO.FeverReportUpdateDTO feverReportRequestDTO, @PathVariable("reportId") long reportId) {
+        feverReportService.updateFeverReport(parent,reportId, feverReportRequestDTO);
+        return CustomResponse.onSuccess("발열 리포트 수정 완료");
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -1,9 +1,18 @@
 package final_project.momeasy.domain.fever_report.converter;
 
 
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_graph.converter.FeverGraphConverter;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.humidity_graph.converter.HumidityGraphConverter;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import final_project.momeasy.domain.temperature_graph.converter.TemperatureGraphConverter;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+
+import java.util.List;
 
 
 public class FeverReportConverter {
@@ -17,11 +26,79 @@ public class FeverReportConverter {
                 .build();
     }
 
+    public static FeverReportResponseDTO.FeverReportDetailViewDTO toFeverReportDetailDTO(FeverReport feverReport,
+         List<FeverGraph> feverGraphs, List<HumidityGraph> humidityGraphs, List<TemperatureGraph> temperatureGraphs) {
+        return FeverReportResponseDTO.FeverReportDetailViewDTO.builder()
+                .outing(feverReport.getOuting())
+                .special(feverReport.getSpecial())
+                .etc_symptom(feverReport.getEtc_symptom())
+                .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom -> FeverReportSymptom.getSymptom().getSymptom()).toList())
+                .createdAt(feverReport.getCreatedAt())
+                .day1(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day1))
+                .day3(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day3))
+                .day7(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day7))
+                .build();
+    }
+
+    public static FeverReportResponseDTO.FeverReportCreateDTO toFeverReportCreateDTO(FeverReport feverReport,
+         List<FeverGraph> feverGraphs, List<HumidityGraph> humidityGraphs, List<TemperatureGraph> temperatureGraphs) {
+        return FeverReportResponseDTO.FeverReportCreateDTO.builder()
+                .outing(feverReport.getOuting())
+                .special(feverReport.getSpecial())
+                .etc_symptom(feverReport.getEtc_symptom())
+                .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom -> FeverReportSymptom.getSymptom().getSymptom()).toList())
+                .createdAt(feverReport.getCreatedAt())
+                .day1(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day1))
+                .day3(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day3))
+                .day7(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day7))
+                .build();
+    }
+
     public static FeverReport toFeverReport(FeverReportRequestDTO.FeverReportCreateDTO feverReportCreateDTO, String special) {
         return FeverReport.builder()
                 .outing(feverReportCreateDTO.getOuting())
                 .special(special)
                 .etc_symptom(feverReportCreateDTO.getEtc_symptom())
+                .build();
+    }
+
+    private static FeverReportResponseDTO.FeverReportDetailViewDTO.GraphGroupDTO getGraphGroupViewDTO(List<FeverGraph> feverGraphs,
+                                                                                                      List<HumidityGraph> humidityGraphs,
+                                                                                                      List<TemperatureGraph> temperatureGraphs,
+                                                                                                  DayRange dayRange) {
+        return FeverReportResponseDTO.FeverReportDetailViewDTO.GraphGroupDTO.builder()
+                .fever(feverGraphs.stream()
+                        .filter(graph -> graph.getDayRange() == dayRange)
+                        .map(FeverGraphConverter::toFeverGraphViewDTO)
+                        .toList())
+                .temperature(temperatureGraphs.stream()
+                       .filter(graph -> graph.getDayRange() == dayRange)
+                       .map(TemperatureGraphConverter::toTemperatureGraphViewDTO)
+                        .toList())
+                .humidity(humidityGraphs.stream()
+                        .filter(graph -> graph.getDayRange() == dayRange)
+                        .map(HumidityGraphConverter::toHumidityGraphViewDTO)
+                        .toList())
+                .build();
+    }
+
+    private static FeverReportResponseDTO.FeverReportCreateDTO.GraphGroupDTO getGraphGroupCreateDTO(List<FeverGraph> feverGraphs,
+                                                                                                    List<HumidityGraph> humidityGraphs,
+                                                                                                    List<TemperatureGraph> temperatureGraphs,
+                                                                                                  DayRange dayRange) {
+        return FeverReportResponseDTO.FeverReportCreateDTO.GraphGroupDTO.builder()
+                .fever(feverGraphs.stream()
+                        .filter(graph -> graph.getDayRange() == dayRange)
+                        .map(FeverGraphConverter::toFeverGraphCreateDTO)
+                        .toList())
+                .temperature(temperatureGraphs.stream()
+                        .filter(graph -> graph.getDayRange() == dayRange)
+                        .map(TemperatureGraphConverter::toTemperatureGraphCreateDTO)
+                        .toList())
+                .humidity(humidityGraphs.stream()
+                        .filter(graph -> graph.getDayRange() == dayRange)
+                       .map(HumidityGraphConverter::toHumidityGraphCreateDTO)
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/converter/FeverReportConverter.java
@@ -34,9 +34,9 @@ public class FeverReportConverter {
                 .etc_symptom(feverReport.getEtc_symptom())
                 .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom -> FeverReportSymptom.getSymptom().getSymptom()).toList())
                 .createdAt(feverReport.getCreatedAt())
-                .day1(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day1))
-                .day3(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day3))
-                .day7(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day7))
+                .day1(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.DAY1))
+                .day3(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.DAY3))
+                .day7(getGraphGroupViewDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.DAY7))
                 .build();
     }
 
@@ -48,9 +48,9 @@ public class FeverReportConverter {
                 .etc_symptom(feverReport.getEtc_symptom())
                 .symptoms(feverReport.getFeverReportSymptoms().stream().map(FeverReportSymptom -> FeverReportSymptom.getSymptom().getSymptom()).toList())
                 .createdAt(feverReport.getCreatedAt())
-                .day1(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day1))
-                .day3(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day3))
-                .day7(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.Day7))
+                .day1(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.DAY1))
+                .day3(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.DAY3))
+                .day7(getGraphGroupCreateDTO(feverGraphs,humidityGraphs,temperatureGraphs,DayRange.DAY7))
                 .build();
     }
 

--- a/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/dto/FeverReportResponseDTO.java
@@ -1,6 +1,9 @@
 package final_project.momeasy.domain.fever_report.dto;
 
 import final_project.momeasy.common.enums.SymptomType;
+import final_project.momeasy.domain.fever_graph.dto.FeverGraphResponseDTO;
+import final_project.momeasy.domain.humidity_graph.dto.HumidityGraphResponseDTO;
+import final_project.momeasy.domain.temperature_graph.dto.TemperatureGraphResponseDTO;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,5 +23,51 @@ public class FeverReportResponseDTO {
         private String special;
 
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class FeverReportDetailViewDTO {
+
+        private List<SymptomType> symptoms;
+        private String etc_symptom;
+        private String outing;
+        private String special;
+        private LocalDateTime createdAt;
+
+        private GraphGroupDTO day1;
+        private GraphGroupDTO day3;
+        private GraphGroupDTO day7;
+
+        @Getter
+        @Builder
+        public static class GraphGroupDTO {
+            private List<FeverGraphResponseDTO.FeverGraphViewDTO> fever;
+            private List<HumidityGraphResponseDTO.HumidityGraphViewDTO> humidity;
+            private List<TemperatureGraphResponseDTO.TemperatureGraphViewDTO> temperature;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class FeverReportCreateDTO {
+
+        private List<SymptomType> symptoms;
+        private String etc_symptom;
+        private String outing;
+        private String special;
+        private LocalDateTime createdAt;
+
+        private GraphGroupDTO day1;
+        private GraphGroupDTO day3;
+        private GraphGroupDTO day7;
+
+        @Getter
+        @Builder
+        public static class GraphGroupDTO {
+            private List<FeverGraphResponseDTO.FeverGraphCreateDTO> fever;
+            private List<HumidityGraphResponseDTO.HumidityGraphCreateDTO> humidity;
+            private List<TemperatureGraphResponseDTO.TemperatureGraphCreateDTO> temperature;
+        }
     }
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/entity/FeverReport.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/entity/FeverReport.java
@@ -1,7 +1,10 @@
 package final_project.momeasy.domain.fever_report.entity;
 
 import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
 import final_project.momeasy.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,9 +32,22 @@ public class FeverReport extends BaseEntity {
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
 
+    // 이름 카멜 케이스로 변경하기
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "feverreport", cascade = CascadeType.ALL)
     @Builder.Default
     private List<FeverReportSymptom>  feverReportSymptoms = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "feverReport", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<FeverGraph> feverGraphs = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "feverReport", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<HumidityGraph> humidityGraphs = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "feverReport", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<TemperatureGraph> temperatureGraphs = new ArrayList<>();
 
     public void setChild(Child child) {
         this.child = child;

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryService.java
@@ -6,7 +6,7 @@ import final_project.momeasy.domain.parent.entity.Parent;
 import java.util.List;
 
 public interface FeverReportQueryService {
-    FeverReportResponseDTO.FeverReportViewDTO getFeverReport(Parent parent, Long childId, Long reportId);
+    FeverReportResponseDTO.FeverReportDetailViewDTO getFeverReport(Parent parent, Long reportId);
     List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(Parent parent, Long childId, int page);
     List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReportList(Parent parent, Long childId);
 

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
@@ -4,14 +4,19 @@ import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.child.exception.ChildErrorCode;
 import final_project.momeasy.domain.child.exception.ChildException;
 import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+import final_project.momeasy.domain.fever_graph.repository.FeverGraphRepository;
 import final_project.momeasy.domain.fever_report.converter.FeverReportConverter;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.fever_report.entity.FeverReport;
 import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
 import final_project.momeasy.domain.fever_report.exception.FeverReportException;
 import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import final_project.momeasy.domain.humidity_graph.repository.HumidityGraphRepositoy;
 import final_project.momeasy.domain.parent.entity.Parent;
-import final_project.momeasy.domain.parent.entity.ParentChild;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+import final_project.momeasy.domain.temperature_graph.repository.TemperatureGraphRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,15 +30,23 @@ import java.util.List;
 public class FeverReportQueryServiceImpl implements FeverReportQueryService {
     private final FeverReportRepository feverReportRepository;
     private final ChildRepository childRepository;
+    private final FeverGraphRepository feverGraphRepository;
+    private final HumidityGraphRepositoy humidityGraphRepositoy;
+    private final TemperatureGraphRepository temperatureGraphRepository;
 
     @Override
-    public FeverReportResponseDTO.FeverReportViewDTO getFeverReport(Parent parent, Long childId, Long reportId) {
-        childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
-        }
+    public FeverReportResponseDTO.FeverReportDetailViewDTO getFeverReport(Parent parent, Long reportId) {
         FeverReport feverReport = feverReportRepository.findById(reportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
-        return FeverReportConverter.toFeverReportViewDTO(feverReport);
+        Child child = feverReport.getChild();
+        if (!childRepository.existsByChildIdAndParentId(child.getId(), parent.getId())) {
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        List<FeverGraph> feverGraphs = feverGraphRepository.findByFeverReport(feverReport);
+        List<HumidityGraph> humidityGraphs = humidityGraphRepositoy.findByFeverReport(feverReport);
+        List<TemperatureGraph> temperatureGraphs = temperatureGraphRepository.findByFeverReport(feverReport);
+        return FeverReportConverter.toFeverReportDetailDTO(
+                feverReport,feverGraphs, humidityGraphs,temperatureGraphs
+        );
     }
 
     @Override

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportService.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportService.java
@@ -5,7 +5,7 @@ import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
 import final_project.momeasy.domain.parent.entity.Parent;
 
 public interface FeverReportService {
-    void deleteFeverReport(Parent parent, Long FeverReportId, Long ChildId);
-    FeverReportResponseDTO.FeverReportViewDTO createFeverReport(Parent parent, FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, Long ChildId);
-    void updateFeverReport(Parent parent, Long FeverReportId, Long ChildId, FeverReportRequestDTO.FeverReportUpdateDTO feverReportRequestDTO);
+    void deleteFeverReport(Parent parent, Long FeverReportId);
+    FeverReportResponseDTO.FeverReportCreateDTO createFeverReport(Parent parent, FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, Long ChildId);
+    void updateFeverReport(Parent parent, Long FeverReportId, FeverReportRequestDTO.FeverReportUpdateDTO feverReportRequestDTO);
 }

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportServiceImpl.java
@@ -5,6 +5,8 @@ import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.child.exception.ChildErrorCode;
 import final_project.momeasy.domain.child.exception.ChildException;
 import final_project.momeasy.domain.child.repository.ChildRepository;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+import final_project.momeasy.domain.fever_graph.service.FeverGraphService;
 import final_project.momeasy.domain.fever_report.converter.FeverReportConverter;
 import final_project.momeasy.domain.fever_report.dto.FeverReportRequestDTO;
 import final_project.momeasy.domain.fever_report.dto.FeverReportResponseDTO;
@@ -13,13 +15,18 @@ import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
 import final_project.momeasy.domain.fever_report.exception.FeverReportException;
 import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
 import final_project.momeasy.domain.fever_report.repository.FeverReportSymptomRepository;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import final_project.momeasy.domain.humidity_graph.service.HumidityGraphService;
 import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.symptom.entity.Symptom;
 import final_project.momeasy.domain.symptom.repository.SymptomRepository;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+import final_project.momeasy.domain.temperature_graph.service.TemperatureGraphService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 
 
 @Service
@@ -30,20 +37,23 @@ public class FeverReportServiceImpl implements FeverReportService {
     private final FeverReportSymptomRepository feverReportSymptomRepository;
     private final ChildRepository childRepository;
     private final SymptomRepository symptomRepository;
+    private final FeverGraphService feverGraphService;
+    private final HumidityGraphService humidityGraphService;
+    private final TemperatureGraphService temperatureGraphService;
 
     @Override
-    public void deleteFeverReport(Parent parent, Long FeverReportId, Long ChildId) {
-        childRepository.findById(ChildId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if (!childRepository.existsByChildIdAndParentId(ChildId, parent.getId())) {
-            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
+    public void deleteFeverReport(Parent parent, Long FeverReportId) {
+        FeverReport feverReport = feverReportRepository.findById(FeverReportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+        Child child = feverReport.getChild();
+        if (!childRepository.existsByChildIdAndParentId(child.getId(), parent.getId())) {
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
         }
-        feverReportRepository.findById(FeverReportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
         feverReportRepository.deleteById(FeverReportId);
     }
 
     // TODO: 특이 사항에 AI 소견 기능 넣기
     @Override
-    public FeverReportResponseDTO.FeverReportViewDTO createFeverReport(Parent parent, FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, Long ChildId) {
+    public FeverReportResponseDTO.FeverReportCreateDTO createFeverReport(Parent parent, FeverReportRequestDTO.FeverReportCreateDTO feverReportRequestDTO, Long ChildId) {
         Child child = childRepository.findById(ChildId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if (!childRepository.existsByChildIdAndParentId(ChildId, parent.getId())) {
             throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
@@ -59,16 +69,22 @@ public class FeverReportServiceImpl implements FeverReportService {
                     .build()));
             symptom.addFeverReport(feverReport);
         }
-        return FeverReportConverter.toFeverReportViewDTO(feverReport);
+        // 체온 그래프, 온도 그래프, 습도 그래프 저장
+        List<FeverGraph> feverGraphs = feverGraphService.createFeverRecordGraph(feverReport.getId(), parent, ChildId);
+        List<HumidityGraph> humidityGraphs = humidityGraphService.createHumidityRecordGraph(feverReport.getId(), parent, ChildId);
+        List<TemperatureGraph> temperatureGraphs = temperatureGraphService.createTemperatureRecordGraph(feverReport.getId(), parent, ChildId);
+        return FeverReportConverter.toFeverReportCreateDTO(
+                feverReport,feverGraphs,humidityGraphs,temperatureGraphs
+        );
     }
 
     // TODO: 특이 사항에 AI 소견 기능 넣기
     @Override
-    public void updateFeverReport(Parent parent, Long FeverReportId, Long ChildId, FeverReportRequestDTO.FeverReportUpdateDTO feverReportRequestDTO) {
+    public void updateFeverReport(Parent parent, Long FeverReportId, FeverReportRequestDTO.FeverReportUpdateDTO feverReportRequestDTO) {
         FeverReport feverReport = feverReportRepository.findById(FeverReportId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
-        Child child = childRepository.findById(ChildId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if (!childRepository.existsByChildIdAndParentId(ChildId, parent.getId())) {
-            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
+        Child child = feverReport.getChild();
+        if (!childRepository.existsByChildIdAndParentId(child.getId(), parent.getId())) {
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
         }
         String special = "특이 사항";
         feverReport.updateFeverReport(feverReportRequestDTO,special);

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/converter/HumidityGraphConverter.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/converter/HumidityGraphConverter.java
@@ -1,0 +1,18 @@
+package final_project.momeasy.domain.humidity_graph.converter;
+
+import final_project.momeasy.domain.humidity_graph.dto.HumidityGraphResponseDTO;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+
+public class HumidityGraphConverter {
+    public static HumidityGraphResponseDTO.HumidityGraphCreateDTO toHumidityGraphCreateDTO(HumidityGraph humidityGraph) {
+        return HumidityGraphResponseDTO.HumidityGraphCreateDTO.builder()
+                .humidity(humidityGraph.getHumidity())
+                .build();
+    }
+
+    public static HumidityGraphResponseDTO.HumidityGraphViewDTO toHumidityGraphViewDTO(HumidityGraph humidityGraph) {
+        return HumidityGraphResponseDTO.HumidityGraphViewDTO.builder()
+                .humidity(humidityGraph.getHumidity())
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/dto/HumidityGraphResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/dto/HumidityGraphResponseDTO.java
@@ -1,0 +1,18 @@
+package final_project.momeasy.domain.humidity_graph.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class HumidityGraphResponseDTO {
+    @Getter
+    @Builder
+    public static class HumidityGraphCreateDTO{
+        private float humidity;
+    }
+
+    @Getter
+    @Builder
+    public static class HumidityGraphViewDTO{
+        private float humidity;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/entity/HumidityGraph.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/entity/HumidityGraph.java
@@ -1,0 +1,33 @@
+package final_project.momeasy.domain.humidity_graph.entity;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HumidityGraph {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private float humidity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayRange dayRange;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fever_report_id", nullable = false)
+    private FeverReport feverReport;
+
+    public void setFeverReport(FeverReport feverReport) {
+        this.feverReport = feverReport;
+        feverReport.getHumidityGraphs().add(this);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/exception/HumidityGraphErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/exception/HumidityGraphErrorCode.java
@@ -1,0 +1,17 @@
+package final_project.momeasy.domain.humidity_graph.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum HumidityGraphErrorCode {
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "HUMIDITY_GRAPH401", "습도 그래프에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "HUMIDITY_GRAPH404", "습도 그래프을 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "HUMIDITY_GRAPH500", "습도 그래프 처리 중 서버 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/exception/HumidityGraphException.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/exception/HumidityGraphException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.humidity_graph.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class HumidityGraphException extends CustomException {
+    public HumidityGraphException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/repository/HumidityGraphRepositoy.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/repository/HumidityGraphRepositoy.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.humidity_graph.repository;
+
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HumidityGraphRepositoy extends JpaRepository<HumidityGraph, Integer> {
+    List<HumidityGraph> findByFeverReport(FeverReport feverreport);
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/AvgHumidity.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/AvgHumidity.java
@@ -1,0 +1,46 @@
+package final_project.momeasy.domain.humidity_graph.service;
+
+import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+import final_project.momeasy.domain.room_condition.repository.RoomConditionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class AvgHumidity {
+    private final RoomConditionRepository roomConditionRepository;
+
+    public float getHumidityAvgBy3Hour(int t, Long childId) {
+        LocalDateTime start = LocalDate.now().atTime(t,0);
+        LocalDateTime end = (t == 21)
+                ?LocalDate.now().plusDays(1).atStartOfDay()
+                :LocalDate.now().atTime(t+3,0);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
+        return (float) Math.round(
+                roomConditions.stream()
+                        .mapToDouble(RoomCondition::getHumidity)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10;
+    }
+
+    public float getHumidityAvgByDayAndTimeRange(int day, int t1, int t2, Long childId) {
+        LocalDate now = LocalDate.now().minusDays(day);
+        LocalDateTime start = now.atTime(t1,0);
+        LocalDateTime end = (t2 == 24)
+                ? now.plusDays(1).atStartOfDay()
+                : now.atTime(t2, 0);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
+        return (float) Math.round(
+                roomConditions.stream()
+                        .mapToDouble(RoomCondition::getHumidity)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10;
+    }
+
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/AvgHumidity.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/AvgHumidity.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class AvgHumidity {
     private final RoomConditionRepository roomConditionRepository;
 
-    public float getHumidityAvgBy3Hour(int t, Long childId) {
-        LocalDateTime start = LocalDate.now().atTime(t,0);
-        LocalDateTime end = (t == 21)
+    public float getHumidityAvgBy3Hour(int time, Long childId) {
+        LocalDateTime start = LocalDate.now().atTime(time,0);
+        LocalDateTime end = (time == 21)
                 ?LocalDate.now().plusDays(1).atStartOfDay()
-                :LocalDate.now().atTime(t+3,0);
+                :LocalDate.now().atTime(time+3,0);
         List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
         return (float) Math.round(
                 roomConditions.stream()
@@ -28,12 +28,12 @@ public class AvgHumidity {
         ) / 10;
     }
 
-    public float getHumidityAvgByDayAndTimeRange(int day, int t1, int t2, Long childId) {
+    public float getHumidityAvgByDayAndTimeRange(int day, int time1, int time2, Long childId) {
         LocalDate now = LocalDate.now().minusDays(day);
-        LocalDateTime start = now.atTime(t1,0);
-        LocalDateTime end = (t2 == 24)
+        LocalDateTime start = now.atTime(time1,0);
+        LocalDateTime end = (time2 == 24)
                 ? now.plusDays(1).atStartOfDay()
-                : now.atTime(t2, 0);
+                : now.atTime(time2, 0);
         List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
         return (float) Math.round(
                 roomConditions.stream()

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphService.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphService.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.humidity_graph.service;
+
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import final_project.momeasy.domain.parent.entity.Parent;
+
+import java.util.List;
+
+public interface HumidityGraphService {
+    // service 안에서만 사용 -> entity 반환해도 괜찮음
+    List<HumidityGraph> createHumidityRecordGraph(Long recordId, Parent parent, Long childId);
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphServiceImpl.java
@@ -1,0 +1,58 @@
+package final_project.momeasy.domain.humidity_graph.service;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
+import final_project.momeasy.domain.fever_report.exception.FeverReportException;
+import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import final_project.momeasy.domain.humidity_graph.repository.HumidityGraphRepositoy;
+import final_project.momeasy.domain.parent.entity.Parent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HumidityGraphServiceImpl implements HumidityGraphService {
+    private final HumidityGraphRepositoy humidityGraphRepositoy;
+    private final FeverReportRepository feverReportRepository;
+    private final AvgHumidity avgHumidity;
+
+    @Override
+    public List<HumidityGraph> createHumidityRecordGraph(Long recordId, Parent parent, Long childId) {
+        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+
+        List<HumidityGraph> humidityGraphs = new ArrayList<>();
+        // 범위 day1
+        for(int t = 0 ; t <24 ; t+=3){
+            humidityGraphs.add(buildHumidityGraph(feverReport, 0, DayRange.Day1,t, t, childId));
+        }
+        // 범위 day3
+        for (int d = 2; d >= 0; d--) {
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day3,0, 6,childId));   // 새벽
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day3,6, 12,childId));  // 오전
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day3,12, 24,childId)); // 오후
+        }
+        // 범위 day7
+        for(int d = 6; d>=0; d--){
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day7,0, 24,childId));
+        }
+        humidityGraphRepositoy.saveAll(humidityGraphs);
+        return humidityGraphs;
+    }
+
+    private HumidityGraph buildHumidityGraph(FeverReport feverReport, int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.Day1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        HumidityGraph humidityGraph = HumidityGraph.builder()
+                .humidity(avg)
+                .dayRange(dayRange)
+                .build();
+        humidityGraph.setFeverReport(feverReport);
+        return humidityGraph;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphServiceImpl.java
@@ -30,26 +30,26 @@ public class HumidityGraphServiceImpl implements HumidityGraphService {
         List<HumidityGraph> humidityGraphs = new ArrayList<>();
         // 범위 day1
         for(int t = 0 ; t <24 ; t+=3){
-            humidityGraphs.add(buildHumidityGraph(feverReport, 0, DayRange.Day1,t, t, childId));
+            humidityGraphs.add(buildHumidityGraph(feverReport, 0, DayRange.DAY1,t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day3,0, 6,childId));   // 새벽
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day3,6, 12,childId));  // 오전
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day3,12, 24,childId)); // 오후
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY3,0, 6,childId));   // 새벽
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY3,6, 12,childId));  // 오전
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY3,12, 24,childId)); // 오후
         }
         // 범위 day7
         for(int d = 6; d>=0; d--){
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.Day7,0, 24,childId));
+            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY7,0, 24,childId));
         }
         humidityGraphRepositoy.saveAll(humidityGraphs);
         return humidityGraphs;
     }
 
     private HumidityGraph buildHumidityGraph(FeverReport feverReport, int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.Day1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        float avg = dayRange == DayRange.DAY1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
         HumidityGraph humidityGraph = HumidityGraph.builder()
-                .humidity(avg)
+                .avgHumidity(avg)
                 .dayRange(dayRange)
                 .build();
         humidityGraph.setFeverReport(feverReport);

--- a/src/main/java/final_project/momeasy/domain/room_condition/repository/RoomConditionRepository.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/repository/RoomConditionRepository.java
@@ -22,4 +22,5 @@ public interface RoomConditionRepository extends JpaRepository<RoomCondition, Lo
     @Query("DELETE FROM RoomCondition rc WHERE rc.createdAt < :time") //스케줄링(@Scheduled)과 함께 사용, 30일 분량의 데이터만 저장
     void deleteByCreatedAtBefore(@Param("time") LocalDateTime time);
 
+    List<RoomCondition> findByChildIdAndCreatedAtBetween(Long childId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/converter/TemperatureGraphConverter.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/converter/TemperatureGraphConverter.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.temperature_graph.converter;
+
+
+import final_project.momeasy.domain.temperature_graph.dto.TemperatureGraphResponseDTO;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+
+public class TemperatureGraphConverter {
+    public static TemperatureGraphResponseDTO.TemperatureGraphCreateDTO toTemperatureGraphCreateDTO(TemperatureGraph temperatureGraph) {
+        return TemperatureGraphResponseDTO.TemperatureGraphCreateDTO.builder()
+                .temperature(temperatureGraph.getTemperature())
+                .build();
+    }
+
+    public static TemperatureGraphResponseDTO.TemperatureGraphViewDTO toTemperatureGraphViewDTO(TemperatureGraph temperatureGraph) {
+        return TemperatureGraphResponseDTO.TemperatureGraphViewDTO.builder()
+                .temperature(temperatureGraph.getTemperature())
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/dto/TemperatureGraphResponseDTO.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/dto/TemperatureGraphResponseDTO.java
@@ -1,0 +1,18 @@
+package final_project.momeasy.domain.temperature_graph.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class TemperatureGraphResponseDTO {
+    @Getter
+    @Builder
+    public static class TemperatureGraphCreateDTO{
+        private float temperature;
+    }
+
+    @Getter
+    @Builder
+    public static class TemperatureGraphViewDTO{
+        private float temperature;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/entity/TemperatureGraph.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/entity/TemperatureGraph.java
@@ -1,0 +1,34 @@
+package final_project.momeasy.domain.temperature_graph.entity;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TemperatureGraph extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private float temperature;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayRange dayRange;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fever_report_id", nullable = false)
+    private FeverReport feverReport;
+
+    public void setFeverReport(FeverReport feverReport) {
+        this.feverReport = feverReport;
+        feverReport.getTemperatureGraphs().add(this);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/exception/TemperatureGraphErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/exception/TemperatureGraphErrorCode.java
@@ -1,0 +1,17 @@
+package final_project.momeasy.domain.temperature_graph.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum TemperatureGraphErrorCode {
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "TEMPERATURE_GRAPH401_GRAPH401", "온도 그래프에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "TEMPERATURE_GRAPH401_GRAPH404", "온도 그래프을 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "TEMPERATURE_GRAPH401_GRAPH500", "온도 그래프 처리 중 서버 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/exception/TemperatureGraphException.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/exception/TemperatureGraphException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.temperature_graph.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class TemperatureGraphException extends CustomException {
+    public TemperatureGraphException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/repository/TemperatureGraphRepository.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/repository/TemperatureGraphRepository.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.temperature_graph.repository;
+
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TemperatureGraphRepository extends JpaRepository<TemperatureGraph, Long> {
+    List<TemperatureGraph> findByFeverReport(FeverReport feverreport);
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/AvgTemperature.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/AvgTemperature.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class AvgTemperature {
     private final RoomConditionRepository roomConditionRepository;
 
-    public float getTemperatureAvgBy3Hour(int t, Long childId) {
-        LocalDateTime start = LocalDate.now().atTime(t,0);
-        LocalDateTime end = (t == 21)
+    public float getTemperatureAvgBy3Hour(int time, Long childId) {
+        LocalDateTime start = LocalDate.now().atTime(time,0);
+        LocalDateTime end = (time == 21)
                 ?LocalDate.now().plusDays(1).atStartOfDay()
-                :LocalDate.now().atTime(t+3,0);
+                :LocalDate.now().atTime(time+3,0);
         List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
         return (float) Math.round(
                 roomConditions.stream()
@@ -28,12 +28,12 @@ public class AvgTemperature {
         ) / 10;
     }
 
-    public float getTemperatureAvgByDayAndTimeRange(int day, int t1, int t2, Long childId) {
+    public float getTemperatureAvgByDayAndTimeRange(int day, int time1, int time2, Long childId) {
         LocalDate now = LocalDate.now().minusDays(day);
-        LocalDateTime start = now.atTime(t1,0);
-        LocalDateTime end = (t2 == 24)
+        LocalDateTime start = now.atTime(time1,0);
+        LocalDateTime end = (time2 == 24)
                 ? now.plusDays(1).atStartOfDay()
-                : now.atTime(t2, 0);
+                : now.atTime(time2, 0);
         List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
         return (float) Math.round(
                 roomConditions.stream()

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/AvgTemperature.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/AvgTemperature.java
@@ -1,0 +1,46 @@
+package final_project.momeasy.domain.temperature_graph.service;
+
+import final_project.momeasy.domain.room_condition.entity.RoomCondition;
+import final_project.momeasy.domain.room_condition.repository.RoomConditionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AvgTemperature {
+    private final RoomConditionRepository roomConditionRepository;
+
+    public float getTemperatureAvgBy3Hour(int t, Long childId) {
+        LocalDateTime start = LocalDate.now().atTime(t,0);
+        LocalDateTime end = (t == 21)
+                ?LocalDate.now().plusDays(1).atStartOfDay()
+                :LocalDate.now().atTime(t+3,0);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
+        return (float) Math.round(
+                roomConditions.stream()
+                        .mapToDouble(RoomCondition::getTemperature)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10;
+    }
+
+    public float getTemperatureAvgByDayAndTimeRange(int day, int t1, int t2, Long childId) {
+        LocalDate now = LocalDate.now().minusDays(day);
+        LocalDateTime start = now.atTime(t1,0);
+        LocalDateTime end = (t2 == 24)
+                ? now.plusDays(1).atStartOfDay()
+                : now.atTime(t2, 0);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
+        return (float) Math.round(
+                roomConditions.stream()
+                        .mapToDouble(RoomCondition::getTemperature)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10;
+    }
+
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphService.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphService.java
@@ -1,0 +1,11 @@
+package final_project.momeasy.domain.temperature_graph.service;
+
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+
+import java.util.List;
+
+public interface TemperatureGraphService {
+    // service 안에서만 사용 -> entity 반환해도 괜찮음
+    List<TemperatureGraph> createTemperatureRecordGraph(Long recordId, Parent parent, Long childId);
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphServiceImpl.java
@@ -1,0 +1,58 @@
+package final_project.momeasy.domain.temperature_graph.service;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.fever_report.exception.FeverReportErrorCode;
+import final_project.momeasy.domain.fever_report.exception.FeverReportException;
+import final_project.momeasy.domain.fever_report.repository.FeverReportRepository;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+import final_project.momeasy.domain.temperature_graph.repository.TemperatureGraphRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TemperatureGraphServiceImpl implements TemperatureGraphService {
+    private final TemperatureGraphRepository temperatureGraphRepository;
+    private final FeverReportRepository feverReportRepository;
+    private final AvgTemperature avgTemperature;
+
+    @Override
+    public List<TemperatureGraph> createTemperatureRecordGraph(Long recordId, Parent parent, Long childId) {
+        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+
+        List<TemperatureGraph> temperatureGraphs = new ArrayList<>();
+        // 범위 day1
+        for(int t = 0 ; t <24 ; t+=3){
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, 0, DayRange.Day1,t, t, childId));
+        }
+        // 범위 day3
+        for (int d = 2; d >= 0; d--) {
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day3,0, 6,childId));   // 새벽
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day3,6, 12,childId));  // 오전
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day3,12, 24,childId)); // 오후
+        }
+        // 범위 day7
+        for(int d = 6; d>=0; d--){
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day7,0, 24,childId));
+        }
+        temperatureGraphRepository.saveAll(temperatureGraphs);
+        return temperatureGraphs;
+    }
+
+    private TemperatureGraph buildTemperatureGraph(FeverReport feverReport, int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.Day1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        TemperatureGraph temperatureGraph = TemperatureGraph.builder()
+                .temperature(avg)
+                .dayRange(dayRange)
+                .build();
+        temperatureGraph.setFeverReport(feverReport);
+        return temperatureGraph;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphServiceImpl.java
@@ -30,26 +30,26 @@ public class TemperatureGraphServiceImpl implements TemperatureGraphService {
         List<TemperatureGraph> temperatureGraphs = new ArrayList<>();
         // 범위 day1
         for(int t = 0 ; t <24 ; t+=3){
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, 0, DayRange.Day1,t, t, childId));
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, 0, DayRange.DAY1,t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day3,0, 6,childId));   // 새벽
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day3,6, 12,childId));  // 오전
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day3,12, 24,childId)); // 오후
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY3,0, 6,childId));   // 새벽
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY3,6, 12,childId));  // 오전
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY3,12, 24,childId)); // 오후
         }
         // 범위 day7
         for(int d = 6; d>=0; d--){
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.Day7,0, 24,childId));
+            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY7,0, 24,childId));
         }
         temperatureGraphRepository.saveAll(temperatureGraphs);
         return temperatureGraphs;
     }
 
     private TemperatureGraph buildTemperatureGraph(FeverReport feverReport, int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.Day1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        float avg = dayRange == DayRange.DAY1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
         TemperatureGraph temperatureGraph = TemperatureGraph.builder()
-                .temperature(avg)
+                .avgTemperature(avg)
                 .dayRange(dayRange)
                 .build();
         temperatureGraph.setFeverReport(feverReport);

--- a/src/main/java/final_project/momeasy/global/tcp/TcpServer.java
+++ b/src/main/java/final_project/momeasy/global/tcp/TcpServer.java
@@ -17,10 +17,10 @@ import java.net.Socket;
 public class TcpServer implements CommandLineRunner {
 
     private final SensorDataQueue sensorDataQueue;
+    private final int port = 12345;
 
     @Override
     public void run(String... args) throws Exception {
-        int port = 12345;
         try {
             ServerSocket serverSocket = new ServerSocket(port);
             log.info("TCP Server is running on port {}", port);


### PR DESCRIPTION
## 🔘Part

### #83 
- [x] 온도, 습도, 체온 그래프 엔티티 생성
- [x] 온도, 습도, 체온 시간 범위(3시간, 새벽, 오전, 오후) 평균값 반환 함수 구현 (Avg~.java)
- [x] 온습도, 체온 시간 범위로 조회 (Repository) 
- [x] port 번호 private final로 변경
### #85 
- [x] 발열 리포트 세부 조회, 생성 DTO, converter 추가
- [x] 발열 리포트 생성 시 온도, 습도, 체온 그래프 저장
- [x] 발열 리포트 세부 조회 시 그래프 조회
  <br/>

## ➕ 이슈 링크

83 이슈가 pr되기 전에 85 이슈를 push해버려서 이번 pr에 83,85 이슈가 같이 들어가게 되었습니다.. 죄송합니다 
- #83 
- #85 

<br/>

## 🔎 작업 내용
### #83 
체온 그래프 엔티티 4f7193b313889c8a0ddae2b1d439003262048fb2
습도 그래프 엔티티 772d41dd1451cb63c090c8b19bc10b6f45f36de5
온도 그래프 엔티티 4b7076911410be2b5c745d056d191eb112bec680
port 번호 private final로 변경 5af91ab024268367a4fd673020690c1e99a5d85e
### #85 
발열 리포트 세부 조회, 생성 DTO ec4109dff162ab36ed12736c5c71dc994f16b8b7
발열 리포트 DTO converter 9a28ea8264d44cb3bb4194da6dc3936d5ef5fee3
발열 리포트 세부 조회 시 그래프 주입 9131d1b9950310aed02a6f6ff93e3f852a6945c3
발열 리포트 생성 시 그래프 주입 30fa9a236e15599cc14a6cf2337f9d6b29ec841e
  <br/>

## 이미지 첨부
### #83 
### erd
![image](https://github.com/user-attachments/assets/4df35f8b-5359-44fa-8f93-7523e7f9e961)
그래프를 생성하고 발열 리포트에 저장하기 위해 그래프 엔티티 추가
발열 리포트 (1) : 그래프 (M)
<br/>
### 그래프 파일 구조
![image](https://github.com/user-attachments/assets/bf91441b-e113-4e37-999d-2829fd5f82b2)
추가된 그래프 엔티티에는 controller가 없음.  
<br/>
### FeverReportService.java
![image](https://github.com/user-attachments/assets/6c1448b2-a708-4dd6-a27d-3f8d001a44a1)
그래프의 service 계층은 FeverReportService.java에서 발열리포트 생성 시 사용됨
<br/>
### FeverGraphService.java
![image](https://github.com/user-attachments/assets/f2f86881-a437-4e15-a03f-88af4bdb1541)
2가지 이유로 인해 반환 타입이 DTO가 아닌 Entity임. 
1.controller로 직접 사용자에게 response 되는 구조가 아님. 
2. service 계층에서 사용하고 FeverReportService.java에서 FeverGraphService.java를 편하게 사용하기 위함.
<br/>
### AvgFever.java

그래프 생성, 조회 시에 사용됨
![image](https://github.com/user-attachments/assets/5e710563-1aaf-4388-b68f-d762ac68ae7b)

체온 데이터를 3시간 범위로 나눠 범위에 속하는 데이터의 평균값을 반환
![image](https://github.com/user-attachments/assets/69a9a2ed-6bff-4efb-b2b6-afd607d436da)

체온 데이터를 새벽(0시~6시), 오전(6시~12시), 오후(12시~0시) 범위로 나눠 시간 범위에 속하는 데이터의 평균값을 반환.

---
<br/>

### #85 
### Figma - Graph
![image](https://github.com/user-attachments/assets/bd1e0ce8-57eb-4abc-88fd-8bebcf31ec0a)
그래프 조회 시 1일, 3일, 7일 범위를 정할 수 있음

<br/>

### FeverReportResponseDTO
![image](https://github.com/user-attachments/assets/f379efbe-5eee-42c8-ab1a-a1380905ecf8)
day1,day3,day7 각각에 들어갈 정보가 많기 때문에 GraphGroupDTOclass로 묶음
### 응답 결과
![image](https://github.com/user-attachments/assets/4c8d416a-127d-4438-915a-710cbec8719e)
밑에 humidity, temperature도 똑같은 형식, day3,day7도 day1과 같은 형식

<br/>

### FeverReportConverter
![image](https://github.com/user-attachments/assets/ef18a48a-7160-47dc-bfff-e45f22d22ac4)
toFeverReportDetailDTO에 day1,day3,day7에 그래프를 넣어주기 위한 함수
converter안에서만 사용하기 때문에 private static으로 선언

