### PR TITLE
✨ [FEAT] 로컬 회원가입 시 이메일 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	// Netty
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
+	// Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
@@ -7,6 +7,9 @@ import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.parent.exception.ParentErrorCode;
 import final_project.momeasy.domain.parent.exception.ParentException;
 import final_project.momeasy.domain.parent.repository.ParentRepository;
+import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeErrorCode;
+import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeException;
+import final_project.momeasy.global.util.mail.verification.service.VerificationCodeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,11 +24,16 @@ public class ParentCommandServiceImpl implements ParentCommandService {
 
     private final ParentRepository parentRepository;
     private final PasswordEncoder passwordEncoder;
+    private final VerificationCodeService verificationCodeService;
 
     @Override
     public ParentResponseDTO.ParentCreateResponseDTO createParent(ParentRequestDTO.ParentCreateRequestDTO parentCreateRequestDTO) {
         if (parentRepository.findByEmail(parentCreateRequestDTO.getEmail()).isPresent()) {
             throw new ParentException(ParentErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if (!verificationCodeService.isVerified(parentCreateRequestDTO.getEmail())) {
+            throw new VerificationCodeException(VerificationCodeErrorCode.CODE_NOT_VERIFIED);
         }
 
         // DTO -> Parent

--- a/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
@@ -75,6 +75,7 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/api/auth/signup",
             "/api/auth/login",
+            "/api/email/**",
             "/oauth2/**",
             "/login/**"
     };

--- a/src/main/java/final_project/momeasy/global/util/mail/controller/MailController.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/controller/MailController.java
@@ -1,0 +1,44 @@
+package final_project.momeasy.global.util.mail.controller;
+
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.util.mail.dto.MailDTO;
+import final_project.momeasy.global.util.mail.service.MailService;
+import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeErrorCode;
+import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeException;
+import final_project.momeasy.global.util.mail.verification.service.VerificationCodeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email")
+@Tag(name = "Email", description = "메일 전송 API")
+public class MailController {
+
+    private final MailService mailService;
+    private final VerificationCodeService verificationCodeService;
+
+    @PostMapping("/verification-code")
+    public CustomResponse<String> sendVerificationCode(@RequestBody MailDTO.EmailRequestDTO emailRequestDTO) {
+        mailService.sendVerificationCode(emailRequestDTO.email());
+        return CustomResponse.onSuccess(HttpStatus.OK, "인증코드 전송 완료");
+    }
+
+    @PostMapping("/verification-code/validation")
+    public CustomResponse<String> verifyCode(@RequestBody MailDTO.VerificationRequestDTO emailRequestDTO) {
+        boolean isValid = verificationCodeService.verifyCode(emailRequestDTO.email(), emailRequestDTO.code());
+
+        if (!isValid) {
+            log.warn("[ MailController ] email: {}, code: {}", emailRequestDTO.email(), emailRequestDTO.code());
+            throw new VerificationCodeException(VerificationCodeErrorCode.CODE_MISMATCH);
+        }
+
+        return CustomResponse.onSuccess(HttpStatus.OK, "인증 완료");
+
+    }
+
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/dto/MailDTO.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/dto/MailDTO.java
@@ -1,0 +1,14 @@
+package final_project.momeasy.global.util.mail.dto;
+
+public class MailDTO {
+    public record EmailRequestDTO(
+            String email
+    ) {
+    }
+
+    public record VerificationRequestDTO(
+            String email,
+            String code
+    ) {
+    }
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/exception/MailErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/exception/MailErrorCode.java
@@ -1,0 +1,21 @@
+package final_project.momeasy.global.util.mail.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MailErrorCode implements BaseErrorCode {
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "MAIL400_1", "이메일 형식이 올바르지 않습니다."),
+    INVALID_RECIPIENT(HttpStatus.BAD_REQUEST, "MAIL400_2", "수신자 이메일이 존재하지 않거나 잘못되었습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "MAIL401_1", "메일 서버 인증에 실패했습니다."),
+    CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "MAIL503_1", "메일 서버에 연결할 수 없습니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500_1", "이메일 전송에 실패했습니다."),
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500_2", "메일 처리 중 알 수 없는 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/exception/MailException.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/exception/MailException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.global.util.mail.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class MailException extends CustomException {
+    public MailException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/service/MailService.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/service/MailService.java
@@ -1,0 +1,8 @@
+package final_project.momeasy.global.util.mail.service;
+
+public interface MailService {
+
+    void sendMail(String to, String subject, String body);
+
+    void sendVerificationCode(String email);
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/service/MailServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/service/MailServiceImpl.java
@@ -1,0 +1,39 @@
+package final_project.momeasy.global.util.mail.service;
+
+import final_project.momeasy.global.util.mail.verification.service.VerificationCodeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MailServiceImpl implements MailService {
+
+    private final JavaMailSender mailSender;
+    private final VerificationCodeService verificationCodeService;
+
+    @Override
+    public void sendMail(String to, String subject, String body) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(body);
+        mailSender.send(message);
+    }
+
+    @Override
+    public void sendVerificationCode(String email) {
+        String code = verificationCodeService.generateAndStoreCode(email);
+
+        String subject = "[맘편해] 이메일 인증 코드입니다.";
+        String body = "인증 코드: " + code + "\n(유효 시간: 5분)";
+
+        sendMail(email, subject, body);
+    }
+
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/service/MailServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/service/MailServiceImpl.java
@@ -6,12 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MailServiceImpl implements MailService {
 
     private final JavaMailSender mailSender;

--- a/src/main/java/final_project/momeasy/global/util/mail/verification/exception/VerificationCodeErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/verification/exception/VerificationCodeErrorCode.java
@@ -1,0 +1,23 @@
+package final_project.momeasy.global.util.mail.verification.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum VerificationCodeErrorCode implements BaseErrorCode {
+    CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "VERI404_1", "인증 코드가 존재하지 않습니다."),
+    CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "VERI401_1", "인증 코드가 만료되었습니다."),
+    CODE_MISMATCH(HttpStatus.BAD_REQUEST, "VERI400_1", "인증 코드가 일치하지 않습니다."),
+    CODE_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "VERI400_2", "이미 인증이 완료된 이메일입니다."),
+    CODE_NOT_VERIFIED(HttpStatus.FORBIDDEN, "VERI403_1", "이메일 인증이 완료되지 않았습니다."),
+    CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "VERI500_1", "인증 코드 생성에 실패했습니다."),
+    REDIS_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "VERI500_2", "인증 코드를 저장하는 데 실패했습니다."),
+    REDIS_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "VERI500_3", "저장된 인증 정보를 불러오는 데 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/verification/exception/VerificationCodeException.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/verification/exception/VerificationCodeException.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.global.util.mail.verification.exception;
+
+import final_project.momeasy.global.apiPayload.code.BaseErrorCode;
+import final_project.momeasy.global.apiPayload.exception.CustomException;
+
+public class VerificationCodeException extends CustomException {
+    public VerificationCodeException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/verification/service/VerificationCodeService.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/verification/service/VerificationCodeService.java
@@ -1,0 +1,12 @@
+package final_project.momeasy.global.util.mail.verification.service;
+
+public interface VerificationCodeService {
+
+    boolean verifyCode(String email, String code);
+
+    String generateAndStoreCode(String email);
+
+    void markAsVerified(String email);
+
+    boolean isVerified(String email);
+}

--- a/src/main/java/final_project/momeasy/global/util/mail/verification/service/VerificationCodeServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/verification/service/VerificationCodeServiceImpl.java
@@ -1,0 +1,51 @@
+package final_project.momeasy.global.util.mail.verification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificationCodeServiceImpl implements VerificationCodeService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String generateCode() {
+        return RandomStringUtils.randomNumeric(6);
+    }
+
+    @Override
+    public boolean verifyCode(String email, String code) {
+        String stored = redisTemplate.opsForValue().get(email);
+        if (!code.equals(stored)) {
+            return false;
+        }
+        markAsVerified(email);
+        return true;
+    }
+
+    @Override
+    public String generateAndStoreCode(String email) {
+        String code = generateCode();
+        redisTemplate.opsForValue().set(email, code, 5, TimeUnit.MINUTES);
+        log.info("Stored verification code {}", code);
+        return code;
+    }
+
+    @Override
+    public void markAsVerified(String email) {
+        redisTemplate.opsForValue().set("verified:" + email, "true", Duration.ofMinutes(30));
+    }
+
+    @Override
+    public boolean isVerified(String email) {
+        String result = redisTemplate.opsForValue().get("verified:" + email);
+        return "true".equals(result);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,11 @@ spring:
           auth: true
           starttls:
             enable: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 jwt:
   secretKey: ${SECRET_KEY}
   token:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,17 @@ spring:
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GOOGLE_SMTP_USERNAME}
+    password: ${GOOGLE_SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 jwt:
   secretKey: ${SECRET_KEY}
   token:


### PR DESCRIPTION
## 🔘Part

- [x] 로컬 회원가입 시 이메일 인증 로직 구현
(코드 생성, 저장, 검증)
  <br/>

## ➕ 이슈 링크

- #58 
<br/>

## 🔎 작업 내용
로컬 회원가입 시 이메일 인증을 필수로 요구하는 기능을 구현
- SMTP 설정 및 JavaMailSender 기반 메일 전송 기능 구현
- Redis를 이용한 인증코드 생성, 저장, 검증 로직 구현
  6자리 인증코드 생성 후 5분간 Redis에 저장
  인증 성공 시 verified:{email} 키로 30분간 인증 완료 상태 저장
- 이메일 인증 메일 전송 및 검증 관련 API 추가
- 회원가입 시 이메일 인증 여부 검증
- 인증되지 않은 이메일은 가입 시 예외 처리
- SecurityConfig에 인증 관련 경로 예외 처리 추가
(이메일 인증 요청은 인증 없이 접근 가능하도록 설정)

> 인증 흐름:
> 이메일 입력 → 인증코드 발송 → 인증 코드 입력 → 인증 성공 → 회원가입 가능

  <br/>

## 이미지 첨부
인증 코드 전송 예시 (인증코드 전송 전용 구글 계정을 생성하여 사용하였습니다.)
<img alt="image" src="https://github.com/user-attachments/assets/7c9accde-f3cc-4218-b567-74cbe1fb07e4" width="50%" height="50%"/>

이메일 인증 없이 로컬 회원가입을 시도하는 경우
<img alt="image" src="https://github.com/user-attachments/assets/2b9089d6-166b-475c-8961-96f9cf6a7f78" width="50%" height="50%"/>

인증 코드가 일치하지 않는 경우
<img alt="image" src="https://github.com/user-attachments/assets/f3703e23-6e41-4abb-9597-ba8b19fdfa5a" width="50%" height="50%"/>
