### PR TITLE
:bug: [FIX] ec2 서버에서 모든 ip 소켓 통신 허용

### DIFF
--- a/src/main/java/final_project/momeasy/global/tcp/TcpServer.java
+++ b/src/main/java/final_project/momeasy/global/tcp/TcpServer.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -22,7 +23,7 @@ public class TcpServer implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         try {
-            ServerSocket serverSocket = new ServerSocket(port);
+            ServerSocket serverSocket = new ServerSocket(port,50, InetAddress.getByName("0.0.0.0"));
             log.info("TCP Server is running on port {}", port);
 
             while (true) {


### PR DESCRIPTION
## 🔘Part

- [x] 어느 ip에서든 소켓 가능하게 코드 변경

  <br/>
## ➕ 이슈 링크

- #100 

<br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요
ServerSocket serverSocket = new ServerSocket(port,50, InetAddress.getByName("0.0.0.0"));
어느 ip에서는 소켓 통신 가능하도록 변경

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
