### PR TITLE
:bug: [FIX] docker에서 12345 port 허용

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,6 +96,7 @@ jobs:
             sudo docker run --name ${{ env.CONTAINER_NAME }} \
               -d \
               -p 8080:8080 \
+              -p 12345:12345 \
               --env-file /home/ubuntu/secrets/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
               ${{ env.DOCKER_IMAGE_NAME }}


### PR DESCRIPTION
## 🔘Part

- [x] ci/cd.yml에 12345 port 추가

  <br/>
## ➕ 이슈 링크

- #102 

<br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요
ec2 서버에서 12345 port로 소켓통신을 하기 위해 ci/cd.yml에 12345 port 추가

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
