### PR TITLE
🔨 [REFACTOR] 예외 처리, 최근 발열 조회 리팩토링

### DIFF
--- a/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordRepository.java
+++ b/src/main/java/final_project/momeasy/domain/fever_record/repository/FeverRecordRepository.java
@@ -17,7 +17,7 @@ public interface FeverRecordRepository extends JpaRepository<FeverRecord, Long> 
     Optional<FeverRecord> findTopByChildIdOrderByCreatedAtDesc(Long childId);
     Slice<FeverRecord> findAllByChildIdOrderByCreatedAtDesc(Long childId, Pageable pageable);
 
-    @Query("SELECT fr FROM FeverRecord fr WHERE fr.child.id  = :childId AND fr.fever>=37.5 ORDER BY fr.createdAt DESC LIMIT 1")
+    @Query("SELECT fr FROM FeverRecord fr WHERE fr.child.id  = :childId AND fr.fever>=37.0 ORDER BY fr.createdAt DESC LIMIT 1")
     Optional<FeverRecord> findRecentFeverRecord(Long childId);
 
     @Transactional

--- a/src/main/java/final_project/momeasy/domain/fever_report/exception/FeverReportErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/exception/FeverReportErrorCode.java
@@ -8,10 +8,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum FeverReportErrorCode implements BaseErrorCode {
-    DELETE_FAILED(HttpStatus.BAD_REQUEST, "FEVER_RECORD400_2", "발열 리포트 정보를 삭제할 수 없습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "FEVER_RECORD401", "발열 리포트에 접근할 수 있는 권한이 없습니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "FEVER_RECORD404", "발열 리포트를 찾을 수 없습니다."),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FEVER_RECORD500", "발열 리포트 처리 중 서버 오류가 발생했습니다.");
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "FEVER_REPORT400_2", "발열 리포트 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "FEVER_REPORT401", "발열 리포트에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "FEVER_REPORT404", "발열 리포트를 찾을 수 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FEVER_REPORT500", "발열 리포트 처리 중 서버 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_report/service/FeverReportQueryServiceImpl.java
@@ -53,7 +53,7 @@ public class FeverReportQueryServiceImpl implements FeverReportQueryService {
     public List<FeverReportResponseDTO.FeverReportViewDTO> getFeverReports(Parent parent, Long childId, int page) {
         childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
+            throw new FeverReportException(FeverReportErrorCode.UNAUTHORIZED_ACCESS);
         }
         Pageable pageable = PageRequest.of(page,10);
         Slice<FeverReport> feverReportSlice = feverReportRepository.findAllByChildIdOrderByIdDesc(childId,pageable);

--- a/src/main/java/final_project/momeasy/domain/home_cam/service/HomecamServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/home_cam/service/HomecamServiceImpl.java
@@ -125,8 +125,11 @@ public class HomecamServiceImpl implements HomecamService {
     public void updateHomecam(HomecamRequestDTO.HomecamUpdateDTO homecamUpdateDTO, Parent parent, Long childId, Long homecamId) {
         Homecam homecam = homecamRepository.findById(homecamId).orElseThrow(()->new HomecamException(HomecamErrorCode.NOT_FOUND));
         Child child = childRepository.findById(childId).orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
-        if(!homecam.getParent().equals(parent) || !childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
+        if(!homecam.getParent().equals(parent)) {
             throw new HomecamException(HomecamErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())){
+            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
         }
         homecam.update(homecamUpdateDTO);
         homecam.setChild(child);

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryServiceImpl.java
@@ -3,8 +3,6 @@ package final_project.momeasy.domain.room_condition.service;
 import final_project.momeasy.domain.child.exception.ChildErrorCode;
 import final_project.momeasy.domain.child.exception.ChildException;
 import final_project.momeasy.domain.child.repository.ChildRepository;
-import final_project.momeasy.domain.fever_record.exception.FeverRecordErrorCode;
-import final_project.momeasy.domain.fever_record.exception.FeverRecordException;
 import final_project.momeasy.domain.humidity_graph.service.AvgHumidity;
 import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.room_condition.converter.RoomConditionConverter;
@@ -35,7 +33,7 @@ public class RoomConditionQueryServiceImpl implements RoomConditionQueryService 
     public RoomConditionResponseDTO.RoomConditionViewDTO getRoomCondition(Long childId, Parent parent) {
         childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
+            throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
         RoomCondition roomCondition = roomConditionRepository.findTopByChildIdOrderByCreatedAtDesc(childId).orElseThrow(()->new RoomConditionException(RoomConditionErrorCode.NOT_FOUND));
         return RoomConditionConverter.toRoomConditionViewDTO(roomCondition);
@@ -45,7 +43,7 @@ public class RoomConditionQueryServiceImpl implements RoomConditionQueryService 
     public List<RoomConditionResponseDTO.RoomConditionViewDTO> getRoomConditionPage(Long childId, int page, Parent parent) {
         childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
+            throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
         Pageable pageable = PageRequest.of(page, 10);
         Slice<RoomCondition> roomConditionList = roomConditionRepository.findAllByChildIdOrderByCreatedAtDesc(childId, pageable);
@@ -61,7 +59,7 @@ public class RoomConditionQueryServiceImpl implements RoomConditionQueryService 
     public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> getRoomConditionGraphDay1(Long childId, Parent parent) {
         childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new FeverRecordException(FeverRecordErrorCode.UNAUTHORIZED_ACCESS);
+            throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
         List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
         for(int t = 0 ; t <24 ; t+=3){
@@ -77,7 +75,7 @@ public class RoomConditionQueryServiceImpl implements RoomConditionQueryService 
     public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> getRoomConditionGraphDay3(Long childId, Parent parent) {
         childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new FeverRecordException(FeverRecordErrorCode.UNAUTHORIZED_ACCESS);
+            throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
         List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
         for(int d=2; d>=0; d--) {
@@ -106,7 +104,7 @@ public class RoomConditionQueryServiceImpl implements RoomConditionQueryService 
     public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> getRoomConditionGraphDay7(Long childId, Parent parent) {
         childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
         if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
-            throw new FeverRecordException(FeverRecordErrorCode.UNAUTHORIZED_ACCESS);
+            throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
         List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
         for(int d = 6; d>=0; d--){


### PR DESCRIPTION
## 🔘Part

- [x] 예외처리를 엔티티와 일치하게 변경
- [x] 발열 기준을 37.0으로 변경 

  <br/>
## ➕ 이슈 링크

- #104 

<br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이

- 구현되었는지 설명해주세요

기존에 feverRecord인데 feverReport 예외처리를 반환하는 등 일치하지 않는 예외처리가 존재
각 서비스 계층의 예외처리를 엔티티와 일치하게 변경
발열 기준을 37.5 -> 37.0으로 변경
  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
