### PR TITLE
✨ [FEAT] Flutter용 소셜 로그인(kakao/naver) API 추가

### DIFF
--- a/src/main/java/final_project/momeasy/common/enums/SocialType.java
+++ b/src/main/java/final_project/momeasy/common/enums/SocialType.java
@@ -1,5 +1,19 @@
 package final_project.momeasy.common.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.util.Arrays;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum SocialType {
-    LOCAL, KAKAO, NAVER, GOOGLE
+    LOCAL, KAKAO, NAVER;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SocialType fromString(String value) {
+        return Arrays.stream(SocialType.values())
+                .filter(v -> v.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 타입: " + value));
+    }
 }

--- a/src/main/java/final_project/momeasy/domain/token/repository/TokenRepository.java
+++ b/src/main/java/final_project/momeasy/domain/token/repository/TokenRepository.java
@@ -10,4 +10,6 @@ public interface TokenRepository extends JpaRepository<Token, Integer> {
     Optional<Token> findByRefreshToken(String token);
 
     void deleteByEmail(String email);
+
+    Optional<Token> findByEmail(String email);
 }

--- a/src/main/java/final_project/momeasy/domain/token/service/TokenService.java
+++ b/src/main/java/final_project/momeasy/domain/token/service/TokenService.java
@@ -32,4 +32,9 @@ public class TokenService {
     public Optional<Token> findByRefreshToken(String token) {
         return tokenRepository.findByRefreshToken(token);
     }
+
+    @Transactional(readOnly = true)
+    public Optional<Token> findByEmail(String email) {
+        return tokenRepository.findByEmail(email);
+    }
 }

--- a/src/main/java/final_project/momeasy/global/auth/client/KakaoOAuthApiClient.java
+++ b/src/main/java/final_project/momeasy/global/auth/client/KakaoOAuthApiClient.java
@@ -1,0 +1,42 @@
+package final_project.momeasy.global.auth.client;
+
+import final_project.momeasy.common.enums.SocialType;
+import final_project.momeasy.global.auth.dto.OAuthAttributes;
+import final_project.momeasy.global.auth.dto.ParentProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthApiClient implements SocialOAuthApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public boolean supports(SocialType provider) {
+        return provider == SocialType.KAKAO;
+    }
+
+    @Override
+    public ParentProfile fetchProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        return OAuthAttributes.extract("kakao", response.getBody());
+    }
+}

--- a/src/main/java/final_project/momeasy/global/auth/client/NaverOAuthApiClient.java
+++ b/src/main/java/final_project/momeasy/global/auth/client/NaverOAuthApiClient.java
@@ -1,0 +1,44 @@
+package final_project.momeasy.global.auth.client;
+
+import final_project.momeasy.common.enums.SocialType;
+import final_project.momeasy.global.auth.dto.OAuthAttributes;
+import final_project.momeasy.global.auth.dto.ParentProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NaverOAuthApiClient implements SocialOAuthApiClient {
+
+    private final RestTemplate restTemplate;
+
+
+    @Override
+    public boolean supports(SocialType provider) {
+        return provider == SocialType.NAVER;
+    }
+
+    @Override
+    public ParentProfile fetchProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://openapi.naver.com/v1/nid/me",
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        Map<String, Object> body = response.getBody();
+        return OAuthAttributes.extract("naver", body);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/auth/client/SocialOAuthApiClient.java
+++ b/src/main/java/final_project/momeasy/global/auth/client/SocialOAuthApiClient.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.global.auth.client;
+
+import final_project.momeasy.common.enums.SocialType;
+import final_project.momeasy.global.auth.dto.ParentProfile;
+
+public interface SocialOAuthApiClient {
+    boolean supports(SocialType provider);
+
+    ParentProfile fetchProfile(String accessToken);
+}

--- a/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
+++ b/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
@@ -3,13 +3,19 @@ package final_project.momeasy.global.auth.controller;
 import final_project.momeasy.domain.parent.dto.request.ParentRequestDTO;
 import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
 import final_project.momeasy.domain.parent.service.command.ParentCommandService;
+import final_project.momeasy.domain.token.service.TokenService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
 import final_project.momeasy.global.auth.dto.request.OAuthRequestDTO;
 import final_project.momeasy.global.auth.dto.response.OAuthResponseDTO;
 import final_project.momeasy.global.auth.service.OAuthLoginService;
 import final_project.momeasy.global.security.dto.request.LoginRequestDTO;
+import final_project.momeasy.global.security.jwt.JwtUtil;
+import final_project.momeasy.global.security.jwt.exception.JwtErrorCode;
+import final_project.momeasy.global.security.jwt.exception.JwtException;
+import final_project.momeasy.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,6 +30,8 @@ public class AuthController {
 
     private final ParentCommandService parentCommandService;
     private final OAuthLoginService oAuthLoginService;
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
 
     @Operation(summary = "로컬 회원가입")
     @PostMapping("/signup")
@@ -47,9 +55,20 @@ public class AuthController {
     }
 
     @Operation(summary = "소셜 로그인 (KAKAO, NAVER)")
-    @PostMapping("/social")
+    @PostMapping("/social-login")
     public CustomResponse<OAuthResponseDTO.OAuthLoginResponseDTO> socialLogin(
-            @RequestBody OAuthRequestDTO.OAuthLoginRequestDTO requestDTO) {
-        return CustomResponse.onSuccess(oAuthLoginService.login(requestDTO));
+            @RequestBody OAuthRequestDTO.OAuthLoginRequestDTO requestDTO,
+            HttpServletResponse response) {
+
+        OAuthResponseDTO.OAuthLoginResponseDTO responseDTO = oAuthLoginService.login(requestDTO);
+
+        String email = jwtUtil.getEmail(responseDTO.accessToken());
+        String refreshToken = tokenService.findByEmail(email)
+                .orElseThrow(() -> new JwtException(JwtErrorCode.MISSING_TOKEN))
+                .getRefreshToken();
+
+        CookieUtil.addRefreshTokenToCookie(response, refreshToken);
+
+        return CustomResponse.onSuccess(responseDTO);
     }
 }

--- a/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
+++ b/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
@@ -4,6 +4,9 @@ import final_project.momeasy.domain.parent.dto.request.ParentRequestDTO;
 import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
 import final_project.momeasy.domain.parent.service.command.ParentCommandService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.auth.dto.request.OAuthRequestDTO;
+import final_project.momeasy.global.auth.dto.response.OAuthResponseDTO;
+import final_project.momeasy.global.auth.service.OAuthLoginService;
 import final_project.momeasy.global.security.dto.request.LoginRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final ParentCommandService parentCommandService;
+    private final OAuthLoginService oAuthLoginService;
 
     @Operation(summary = "로컬 회원가입")
     @PostMapping("/signup")
@@ -40,5 +44,12 @@ public class AuthController {
     @PostMapping("/logout")
     public CustomResponse<?> logout() {
         return null;
+    }
+
+    @Operation(summary = "소셜 로그인 (KAKAO, NAVER)")
+    @PostMapping("/social")
+    public CustomResponse<OAuthResponseDTO.OAuthLoginResponseDTO> socialLogin(
+            @RequestBody OAuthRequestDTO.OAuthLoginRequestDTO requestDTO) {
+        return CustomResponse.onSuccess(oAuthLoginService.login(requestDTO));
     }
 }

--- a/src/main/java/final_project/momeasy/global/auth/dto/request/OAuthRequestDTO.java
+++ b/src/main/java/final_project/momeasy/global/auth/dto/request/OAuthRequestDTO.java
@@ -1,0 +1,13 @@
+package final_project.momeasy.global.auth.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import final_project.momeasy.common.enums.SocialType;
+
+public class OAuthRequestDTO {
+    public record OAuthLoginRequestDTO(
+            @JsonProperty("provider")
+            SocialType provider,
+            String accessToken
+    ) {
+    }
+}

--- a/src/main/java/final_project/momeasy/global/auth/dto/response/OAuthResponseDTO.java
+++ b/src/main/java/final_project/momeasy/global/auth/dto/response/OAuthResponseDTO.java
@@ -2,8 +2,7 @@ package final_project.momeasy.global.auth.dto.response;
 
 public class OAuthResponseDTO {
     public record OAuthLoginResponseDTO(
-            String accessToken,
-            String refreshToken
+            String accessToken
     ) {
     }
 }

--- a/src/main/java/final_project/momeasy/global/auth/dto/response/OAuthResponseDTO.java
+++ b/src/main/java/final_project/momeasy/global/auth/dto/response/OAuthResponseDTO.java
@@ -1,0 +1,9 @@
+package final_project.momeasy.global.auth.dto.response;
+
+public class OAuthResponseDTO {
+    public record OAuthLoginResponseDTO(
+            String accessToken,
+            String refreshToken
+    ) {
+    }
+}

--- a/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginService.java
+++ b/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginService.java
@@ -1,0 +1,8 @@
+package final_project.momeasy.global.auth.service;
+
+import final_project.momeasy.global.auth.dto.request.OAuthRequestDTO;
+import final_project.momeasy.global.auth.dto.response.OAuthResponseDTO;
+
+public interface OAuthLoginService {
+    OAuthResponseDTO.OAuthLoginResponseDTO login(OAuthRequestDTO.OAuthLoginRequestDTO oAuthLoginRequestDTO);
+}

--- a/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
@@ -53,6 +53,6 @@ public class OAuthLoginServiceImpl implements OAuthLoginService {
 
         tokenService.saveOrUpdate(parent.getEmail(), refreshJwt);
 
-        return new OAuthResponseDTO.OAuthLoginResponseDTO(accessJwt, refreshJwt);
+        return new OAuthResponseDTO.OAuthLoginResponseDTO(accessJwt);
     }
 }

--- a/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
@@ -1,0 +1,58 @@
+package final_project.momeasy.global.auth.service;
+
+import final_project.momeasy.domain.parent.converter.ParentConverter;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.parent.repository.ParentRepository;
+import final_project.momeasy.domain.token.service.TokenService;
+import final_project.momeasy.global.auth.client.SocialOAuthApiClient;
+import final_project.momeasy.global.auth.dto.ParentProfile;
+import final_project.momeasy.global.auth.dto.request.OAuthRequestDTO;
+import final_project.momeasy.global.auth.dto.response.OAuthResponseDTO;
+import final_project.momeasy.global.security.CustomUserDetails;
+import final_project.momeasy.global.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthLoginServiceImpl implements OAuthLoginService {
+
+    private final List<SocialOAuthApiClient> socialOAuthApiClients;
+    private final ParentRepository parentRepository;
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
+
+    public OAuthResponseDTO.OAuthLoginResponseDTO login(OAuthRequestDTO.OAuthLoginRequestDTO oAuthLoginRequestDTO) {
+
+        // API Client 찾기
+        SocialOAuthApiClient client = socialOAuthApiClients.stream()
+                .filter(c -> c.supports(oAuthLoginRequestDTO.provider()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + oAuthLoginRequestDTO.provider()));
+
+        // 사용자 정보 요청
+        ParentProfile profile = client.fetchProfile(oAuthLoginRequestDTO.accessToken());
+
+        // 기존 유저 조회 or 회원가입
+        log.info("[ OAuthLoginServiceImpl ] 이메일로 사용자 조회 중: {}", profile.getEmail());
+
+        Parent parent = parentRepository.findByEmail(profile.getEmail())
+                .orElseGet(() -> {
+                    log.info("[ OAuthLoginServiceImpl ] 신규 사용자입니다. 회원 가입을 진행합니다.");
+                    return parentRepository.save(ParentConverter.toParentFromProfile(profile));
+                });
+
+        // JWT 발급
+        CustomUserDetails userDetails = new CustomUserDetails(parent);
+        String accessJwt = jwtUtil.generateJwtAccessToken(userDetails);
+        String refreshJwt = jwtUtil.generateRefreshToken(userDetails);
+
+        tokenService.saveOrUpdate(parent.getEmail(), refreshJwt);
+
+        return new OAuthResponseDTO.OAuthLoginResponseDTO(accessJwt, refreshJwt);
+    }
+}

--- a/src/main/java/final_project/momeasy/global/config/AppConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/AppConfig.java
@@ -1,0 +1,14 @@
+package final_project.momeasy.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
@@ -73,10 +73,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/swagger-resources/**",
-            "/api/auth/signup",
-            "/api/auth/login",
+            "/api/auth/**",
             "/api/email/**",
-            "/oauth2/**",
             "/login/**"
     };
 
@@ -108,13 +106,13 @@ public class SecurityConfig {
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))
 
-                // oauth2 로그인
-                .oauth2Login(oauth -> oauth
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuthUserService)
-                        )
-                        .successHandler(oAuth2LoginSuccessHandler)
-                )
+//                // oauth2 로그인
+//                .oauth2Login(oauth -> oauth
+//                        .userInfoEndpoint(userInfo -> userInfo
+//                                .userService(customOAuthUserService)
+//                        )
+//                        .successHandler(oAuth2LoginSuccessHandler)
+//                )
 
                 // 로그아웃
                 .logout(logout -> logout


### PR DESCRIPTION
## 🔘Part

- [x] 소셜 로그인 플러터에 알맞게 수정

  <br/>
## ➕ 이슈 링크

- #80 

<br/>

## 🔎 작업 내용

**Flutter용 소셜 로그인 OAuth 서비스 재구현**
- SecurityConfig에서 기존 OAuth2 설정 제거
- OAuthLoginService 및 플랫폼별 클라이언트 로직 구현 + 인터페이스 분리
- SocialType enum 역직렬화 처리 (@JsonCreator) 및 문자열 기반 파싱 로직 추가
- RestTemplate Bean 등록을 통한 외부 API 호출 지원 (AppConfig)
- refresh token 쿠키 설정 로직 수정 (응답에 담겨 클라이언트 저장 가능)

  <br/>

## 이미지 첨부

<img src="https://github.com/user-attachments/assets/3c7be67c-d7da-4ef8-b2aa-312acd68ee42" width="70%"/>
<img src="https://github.com/user-attachments/assets/36027d3d-f928-46a3-a652-af587aae78c9" width="70%"/>
<br/>
