### PR TITLE
✨ [FEAT] 프로필 이미지 저장 (S3 이용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/final_project/momeasy/domain/parent/controller/ParentController.java
+++ b/src/main/java/final_project/momeasy/domain/parent/controller/ParentController.java
@@ -7,10 +7,16 @@ import final_project.momeasy.domain.parent.service.command.ParentCommandService;
 import final_project.momeasy.domain.parent.service.query.ParentQueryService;
 import final_project.momeasy.global.apiPayload.CustomResponse;
 import final_project.momeasy.global.security.annotation.AuthParent;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
+
+@Tag(name = "Parent", description = "부모(회원) API by 현빈")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/my")
@@ -40,5 +46,12 @@ public class ParentController {
         return CustomResponse.onSuccess(HttpStatus.CREATED, "회원 정보 수정 완료");
     }
 
-
+    @PatchMapping("/profile-image")
+    public CustomResponse<?> updateProfileImage(
+            @AuthParent Parent parent,
+            @RequestPart MultipartFile profileImage
+            ) throws IOException {
+        String profileUrl = parentCommandService.updateProfileImage(parent.getId(), profileImage);
+        return CustomResponse.onSuccess(profileUrl);
+    }
 }

--- a/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
+++ b/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
@@ -114,4 +114,8 @@ public class Parent extends BaseEntity {
         this.birthdate = birthdate;
         this.gender = gender;
     }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
+++ b/src/main/java/final_project/momeasy/domain/parent/exception/ParentErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ParentErrorCode implements BaseErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "PARENT400", "필수 동의사항에 모두 동의해야 회원가입이 가능합니다."),
     LOGIN_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PARENT400_1", "해당 LoginID가 이미 존재합니다."),
+    IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "PARENT400_2", "프로필 이미지가 제공되지 않았습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "PARENT409_1", "이미 사용 중인 이메일입니다."),
     DUPLICATE_ID(HttpStatus.CONFLICT, "PARENT409_2", "이미 사용 중인 아이디입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT404", "회원을 찾을 수 없습니다.");

--- a/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandService.java
+++ b/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandService.java
@@ -2,6 +2,9 @@ package final_project.momeasy.domain.parent.service.command;
 
 import final_project.momeasy.domain.parent.dto.request.ParentRequestDTO;
 import final_project.momeasy.domain.parent.dto.response.ParentResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 public interface ParentCommandService {
 
@@ -10,4 +13,6 @@ public interface ParentCommandService {
     void deleteParent(Long parentId);
 
     void updateParent(Long parentId, ParentRequestDTO.ParentUpdateRequestDTO dto);
+
+    String updateProfileImage(Long parentId, MultipartFile profileImage) throws IOException;
 }

--- a/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
@@ -13,11 +13,15 @@ import final_project.momeasy.global.auth.exception.AuthException;
 import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeErrorCode;
 import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeException;
 import final_project.momeasy.global.util.mail.verification.service.VerificationCodeService;
+import final_project.momeasy.global.util.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Slf4j
 @Service
@@ -28,19 +32,20 @@ public class ParentCommandServiceImpl implements ParentCommandService {
     private final ParentRepository parentRepository;
     private final PasswordEncoder passwordEncoder;
     private final VerificationCodeService verificationCodeService;
+    private final S3Uploader s3Uploader;
 
     @Override
-    public ParentResponseDTO.ParentCreateResponseDTO createParent(ParentRequestDTO.ParentCreateRequestDTO parentCreateRequestDTO) {
-        if (parentRepository.findByEmail(parentCreateRequestDTO.getEmail()).isPresent()) {
+    public ParentResponseDTO.ParentCreateResponseDTO createParent(ParentRequestDTO.ParentCreateRequestDTO dto) {
+        if (parentRepository.findByEmail(dto.getEmail()).isPresent()) {
             throw new ParentException(ParentErrorCode.DUPLICATE_EMAIL);
         }
 
-        if (!verificationCodeService.isVerified(parentCreateRequestDTO.getEmail())) {
+        if (!verificationCodeService.isVerified(dto.getEmail())) {
             throw new VerificationCodeException(VerificationCodeErrorCode.CODE_NOT_VERIFIED);
         }
 
         // DTO -> Parent
-        Parent parent = ParentConverter.toParent(parentCreateRequestDTO, passwordEncoder);
+        Parent parent = ParentConverter.toParent(dto, passwordEncoder);
 
         // DB에 저장
         parentRepository.save(parent);
@@ -78,4 +83,26 @@ public class ParentCommandServiceImpl implements ParentCommandService {
         parentRepository.save(parent);
     }
 
+    @Override
+    public String updateProfileImage(Long parentId, MultipartFile profileImage) throws IOException {
+        Parent parent = parentRepository.findByIdNotDeleted(parentId)
+                .orElseThrow(() -> new ParentException(ParentErrorCode.NOT_FOUND));
+
+        if (profileImage == null || profileImage.isEmpty()) {
+            throw new ParentException(ParentErrorCode.IMAGE_NOT_PROVIDED);
+        }
+
+        // 기존 이미지 있으면 삭제
+        if (parent.getProfileImage() != null) {
+            s3Uploader.delete(parent.getProfileImage());
+        }
+
+        // 새로운 이미지 업로드
+        String fileName = s3Uploader.upload(profileImage, "profile");
+        parent.updateProfileImage(fileName);
+
+        parentRepository.save(parent);
+
+        return s3Uploader.getPresignedUrl(fileName);
+    }
 }

--- a/src/main/java/final_project/momeasy/global/config/S3Config.java
+++ b/src/main/java/final_project/momeasy/global/config/S3Config.java
@@ -1,0 +1,29 @@
+package final_project.momeasy.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion("ap-northeast-2")
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/global/util/s3/S3Uploader.java
+++ b/src/main/java/final_project/momeasy/global/util/s3/S3Uploader.java
@@ -1,0 +1,56 @@
+package final_project.momeasy.global.util.s3;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    // 파일 업로드
+    public String upload(MultipartFile file, String dirName) throws IOException {
+        String fileName = dirName + "/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata));
+
+        return fileName;
+    }
+
+    // 삭제
+    public void delete(String fileName) {
+        amazonS3.deleteObject(bucket, fileName);
+    }
+
+    // 접근용 presigned URL 생성
+    public String getPresignedUrl(String fileName) {
+        Date expiration = new Date(System.currentTimeMillis() + 100 * 60 * 60); // 1시간 유효
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, fileName)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration);
+
+        return amazonS3.generatePresignedUrl(request).toString();
+
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,19 @@ jwt:
   token:
     access-expiration-time: 3600000     # 1 hour (ms)
     refresh-expiration-time: 86400000   # 24 hours (ms)
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-22
+    s3:
+      bucket: ${AWS_BUCKET_NAME}
+    stack:
+      auto: false
+
 ---
 spring:
   config:
@@ -152,6 +165,18 @@ jwt:
   token:
     access-expiration-time: 3600000     # 1 hour (ms)
     refresh-expiration-time: 86400000   # 24 hours (ms)
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${AWS_BUCKET_NAME}
+    stack:
+      auto: false
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

- #117 

<br/>

## 🔎 작업 내용

- S3를 이용해서 프로필 이미지 저장할 수 있게 했습니다-!!!!!
피그마 상으로 회원가입할 때는 없고 정보 수정에서만 할 수 있다구 해서 그렇게 했구여
프론트에서 프로필 이미지만 따로 form-data로 하는 게 좋다구 해서 그렇게 해씀니다요 @choi0510 
- 아맞다 s3는 IAM USER 만들어서 권한 설정 따로 해서 했습니다
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/d4733c29-a1fb-4f34-a8b5-ea7329c7d8a5" />

  <br/>

## 이미지 첨부

<img width="674" alt="image" src="https://github.com/user-attachments/assets/8358cfb4-0347-4d50-b1ac-a62428e91f49" />
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/77ee4b81-6ba3-45b1-b247-48b3810bbeed" />
저장 잘 됩니다요
<br/>
