### PR TITLE
✨ [FEAT] Notification 도메인 기능 구현

### DIFF
--- a/src/main/java/final_project/momeasy/common/enums/NotificationType.java
+++ b/src/main/java/final_project/momeasy/common/enums/NotificationType.java
@@ -1,0 +1,12 @@
+package final_project.momeasy.common.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    CARE("케어 알림");  // 체온 + 온습도 알림 통합
+
+    private final String description;
+}

--- a/src/main/java/final_project/momeasy/domain/notification/controller/NotificationController.java
+++ b/src/main/java/final_project/momeasy/domain/notification/controller/NotificationController.java
@@ -1,0 +1,46 @@
+package final_project.momeasy.domain.notification.controller;
+
+import final_project.momeasy.domain.notification.dto.NotificationRequest;
+import final_project.momeasy.domain.notification.dto.NotificationResponse;
+import final_project.momeasy.domain.notification.service.NotificationService;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.security.annotation.AuthParent;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "부모의 알림 목록 조회")
+    @GetMapping
+    public CustomResponse<List<NotificationResponse>> getNotifications(@AuthParent Parent parent) {
+        List<NotificationResponse> notifications = notificationService.getNotifications(parent);
+        return CustomResponse.onSuccess(notifications);
+    }
+
+    @Operation(summary = "알림 읽음 처리")
+    @PatchMapping("/{notificationId}/read")
+    public CustomResponse<Void> markAsRead(
+            @AuthParent Parent parent,
+            @PathVariable Long notificationId) {
+        notificationService.markAsRead(parent, notificationId);
+        return CustomResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "알림 생성")
+    @PostMapping
+    public CustomResponse<Void> createNotification(
+            @AuthParent Parent parent,
+            @RequestBody NotificationRequest request) {
+        notificationService.createNotification(parent, request);
+        return CustomResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/notification/controller/NotificationController.java
+++ b/src/main/java/final_project/momeasy/domain/notification/controller/NotificationController.java
@@ -1,16 +1,14 @@
 package final_project.momeasy.domain.notification.controller;
 
-import final_project.momeasy.domain.notification.dto.NotificationRequest;
 import final_project.momeasy.domain.notification.dto.NotificationResponse;
 import final_project.momeasy.domain.notification.service.NotificationService;
 import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.apiPayload.CursorResponse;
 import final_project.momeasy.global.security.annotation.AuthParent;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -19,10 +17,16 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @Operation(summary = "부모의 알림 목록 조회")
+    @Operation(summary = "부모의 알림 목록 조회 (커서 기반 페이지네이션)")
     @GetMapping
-    public CustomResponse<List<NotificationResponse>> getNotifications(@AuthParent Parent parent) {
-        List<NotificationResponse> notifications = notificationService.getNotifications(parent);
+    public CustomResponse<CursorResponse<NotificationResponse>> getNotifications(
+            @AuthParent Parent parent,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size) {
+
+        CursorResponse<NotificationResponse> notifications =
+                notificationService.getNotifications(parent, cursor, size);
+
         return CustomResponse.onSuccess(notifications);
     }
 
@@ -31,16 +35,8 @@ public class NotificationController {
     public CustomResponse<Void> markAsRead(
             @AuthParent Parent parent,
             @PathVariable Long notificationId) {
-        notificationService.markAsRead(parent, notificationId);
-        return CustomResponse.onSuccess(null);
-    }
 
-    @Operation(summary = "알림 생성")
-    @PostMapping
-    public CustomResponse<Void> createNotification(
-            @AuthParent Parent parent,
-            @RequestBody NotificationRequest request) {
-        notificationService.createNotification(parent, request);
+        notificationService.markAsRead(parent, notificationId);
         return CustomResponse.onSuccess(null);
     }
 }

--- a/src/main/java/final_project/momeasy/domain/notification/controller/NotificationController.java
+++ b/src/main/java/final_project/momeasy/domain/notification/controller/NotificationController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
 public class NotificationController {

--- a/src/main/java/final_project/momeasy/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/final_project/momeasy/domain/notification/converter/NotificationConverter.java
@@ -12,7 +12,7 @@ public class NotificationConverter {
         return NotificationResponse.from(notification);
     }
 
-    // 🔧 직접 파라미터 전달 방식
+    // 직접 파라미터 전달 방식
     public static Notification from(
             Parent parent,
             Child child,

--- a/src/main/java/final_project/momeasy/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/final_project/momeasy/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,28 @@
+package final_project.momeasy.domain.notification.converter;
+
+import final_project.momeasy.common.enums.NotificationType;
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.notification.dto.NotificationRequest;
+import final_project.momeasy.domain.notification.dto.NotificationResponse;
+import final_project.momeasy.domain.notification.entity.Notification;
+import final_project.momeasy.domain.parent.entity.Parent;
+
+public class NotificationConverter {
+
+    public static NotificationResponse toResponse(Notification notification) {
+        return NotificationResponse.from(notification);
+    }
+
+    public static Notification fromRequest(NotificationRequest request, Parent parent, Child child) {
+        return Notification.builder()
+                .parent(parent)
+                .child(child)
+                .type(NotificationType.CARE)
+                .message(request.getMessage())
+                .fever(request.getFever())
+                .temperature(request.getTemperature())
+                .humidity(request.getHumidity())
+                .isRead(false)
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/final_project/momeasy/domain/notification/converter/NotificationConverter.java
@@ -2,7 +2,6 @@ package final_project.momeasy.domain.notification.converter;
 
 import final_project.momeasy.common.enums.NotificationType;
 import final_project.momeasy.domain.child.entity.Child;
-import final_project.momeasy.domain.notification.dto.NotificationRequest;
 import final_project.momeasy.domain.notification.dto.NotificationResponse;
 import final_project.momeasy.domain.notification.entity.Notification;
 import final_project.momeasy.domain.parent.entity.Parent;
@@ -13,15 +12,23 @@ public class NotificationConverter {
         return NotificationResponse.from(notification);
     }
 
-    public static Notification fromRequest(NotificationRequest request, Parent parent, Child child) {
+    // 🔧 직접 파라미터 전달 방식
+    public static Notification from(
+            Parent parent,
+            Child child,
+            String message,
+            Float fever,
+            Float temperature,
+            Float humidity
+    ) {
         return Notification.builder()
                 .parent(parent)
                 .child(child)
                 .type(NotificationType.CARE)
-                .message(request.getMessage())
-                .fever(request.getFever())
-                .temperature(request.getTemperature())
-                .humidity(request.getHumidity())
+                .message(message)
+                .fever(fever)
+                .temperature(temperature)
+                .humidity(humidity)
                 .isRead(false)
                 .build();
     }

--- a/src/main/java/final_project/momeasy/domain/notification/dto/NotificationRequest.java
+++ b/src/main/java/final_project/momeasy/domain/notification/dto/NotificationRequest.java
@@ -1,0 +1,19 @@
+package final_project.momeasy.domain.notification.dto;
+
+import final_project.momeasy.common.enums.NotificationType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class NotificationRequest {
+
+    @NotNull(message = "알림 메시지는 필수입니다.")
+    private String message;
+
+    private Float fever;           // 체온 (nullable)
+    private Float temperature;     // 온도 (nullable)
+    private Float humidity;        // 습도 (nullable)
+
+    @NotNull(message = "child_Id는 필수입니다.")
+    private Long childId;
+}

--- a/src/main/java/final_project/momeasy/domain/notification/dto/NotificationRequest.java
+++ b/src/main/java/final_project/momeasy/domain/notification/dto/NotificationRequest.java
@@ -1,6 +1,5 @@
 package final_project.momeasy.domain.notification.dto;
 
-import final_project.momeasy.common.enums.NotificationType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 

--- a/src/main/java/final_project/momeasy/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/final_project/momeasy/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,37 @@
+package final_project.momeasy.domain.notification.dto;
+
+import final_project.momeasy.common.enums.NotificationType;
+import final_project.momeasy.domain.notification.entity.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NotificationResponse {
+
+    private Long notificationId;
+    private NotificationType type;     // CARE 고정
+    private String message;
+    private Float fever;               // 체온 (nullable)
+    private Float temperature;         // 온도 (nullable)
+    private Float humidity;            // 습도 (nullable)
+    private boolean isRead;
+    private LocalDateTime createdAt;
+    private String childName;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .notificationId(notification.getId())
+                .type(notification.getType())
+                .message(notification.getMessage())
+                .fever(notification.getFever())
+                .temperature(notification.getTemperature())
+                .humidity(notification.getHumidity())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .childName(notification.getChild().getName())
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/notification/entity/Notification.java
+++ b/src/main/java/final_project/momeasy/domain/notification/entity/Notification.java
@@ -3,17 +3,20 @@ package final_project.momeasy.domain.notification.entity;
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.global.entity.BaseEntity;
+import final_project.momeasy.common.enums.NotificationType;
 import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Notification extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "child_id", nullable = false)
@@ -23,12 +26,26 @@ public class Notification extends BaseEntity {
     @JoinColumn(name = "parent_id", nullable = false)
     private Parent parent;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private float fever;
+    private NotificationType type; // CARE 로 고정
+
+    @Column
+    private Float fever;           // 체온
+
+    @Column
+    private Float temperature;     // 방 온도
+
+    @Column
+    private Float humidity;        // 습도
 
     @Column(nullable = false)
     private String message;
 
+    @Column(nullable = false)
+    private boolean isRead;
+
+    // 연관관계 편의 메서드
     public void setChild(Child child) {
         this.child = child;
         child.getNotifications().add(this);
@@ -39,4 +56,7 @@ public class Notification extends BaseEntity {
         parent.getNotifications().add(this);
     }
 
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/final_project/momeasy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/final_project/momeasy/domain/notification/repository/NotificationRepository.java
@@ -2,12 +2,19 @@ package final_project.momeasy.domain.notification.repository;
 
 import final_project.momeasy.domain.notification.entity.Notification;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Slice<Notification> findByParentId(long parentId, Pageable pageable);
+
+    // 커서가 없는 경우 (최신순 전체 페이지 첫 요청)
+    List<Notification> findByParentIdOrderByIdDesc(Long parentId, Pageable pageable);
+
+    // 커서가 있는 경우 (이전 ID보다 작은 데이터만 조회)
+    List<Notification> findByParentIdAndIdLessThanOrderByIdDesc(Long parentId, Long cursorId, Pageable pageable);
+
+    // 기존 용도로 남겨두는 거면 유지, 아니라면 삭제 가능
     Optional<Notification> findTopByParentIdAndChildIdOrderByIdDesc(long parentId, long childId);
 }

--- a/src/main/java/final_project/momeasy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/final_project/momeasy/domain/notification/repository/NotificationRepository.java
@@ -4,12 +4,10 @@ import final_project.momeasy.domain.notification.entity.Notification;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Slice<Notification> findByParentId(long parentid, Pageable pageable);
-    Optional<Notification> findTopByParentIdAndChildIdOrderByIdDesc(long parentid, long childid);
+    Slice<Notification> findByParentId(long parentId, Pageable pageable);
+    Optional<Notification> findTopByParentIdAndChildIdOrderByIdDesc(long parentId, long childId);
 }

--- a/src/main/java/final_project/momeasy/domain/notification/service/NotificationService.java
+++ b/src/main/java/final_project/momeasy/domain/notification/service/NotificationService.java
@@ -1,0 +1,16 @@
+package final_project.momeasy.domain.notification.service;
+
+import final_project.momeasy.domain.notification.dto.NotificationRequest;
+import final_project.momeasy.domain.notification.dto.NotificationResponse;
+import final_project.momeasy.domain.parent.entity.Parent;
+
+import java.util.List;
+
+public interface NotificationService {
+
+    List<NotificationResponse> getNotifications(Parent parent);
+
+    void markAsRead(Parent parent, Long notificationId);
+
+    void createNotification(Parent parent, NotificationRequest request);
+}

--- a/src/main/java/final_project/momeasy/domain/notification/service/NotificationService.java
+++ b/src/main/java/final_project/momeasy/domain/notification/service/NotificationService.java
@@ -1,16 +1,15 @@
 package final_project.momeasy.domain.notification.service;
 
-import final_project.momeasy.domain.notification.dto.NotificationRequest;
 import final_project.momeasy.domain.notification.dto.NotificationResponse;
 import final_project.momeasy.domain.parent.entity.Parent;
-
-import java.util.List;
+import final_project.momeasy.global.apiPayload.CursorResponse;
 
 public interface NotificationService {
 
-    List<NotificationResponse> getNotifications(Parent parent);
+    // 커서 기반 알림 목록 조회
+    CursorResponse<NotificationResponse> getNotifications(Parent parent, Long cursor, int size);
 
     void markAsRead(Parent parent, Long notificationId);
 
-    void createNotification(Parent parent, NotificationRequest request);
+
 }

--- a/src/main/java/final_project/momeasy/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/notification/service/NotificationServiceImpl.java
@@ -2,14 +2,13 @@ package final_project.momeasy.domain.notification.service;
 
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.notification.converter.NotificationConverter;
-import final_project.momeasy.domain.notification.dto.NotificationRequest;
 import final_project.momeasy.domain.notification.dto.NotificationResponse;
 import final_project.momeasy.domain.notification.entity.Notification;
 import final_project.momeasy.domain.notification.exception.NotificationErrorCode;
 import final_project.momeasy.domain.notification.exception.NotificationException;
 import final_project.momeasy.domain.notification.repository.NotificationRepository;
 import final_project.momeasy.domain.parent.entity.Parent;
-import final_project.momeasy.domain.parent.entity.ParentChild;
+import final_project.momeasy.global.apiPayload.CursorResponse;
 import final_project.momeasy.global.fcm.entity.FcmToken;
 import final_project.momeasy.global.fcm.service.FcmService;
 import jakarta.transaction.Transactional;
@@ -29,12 +28,24 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     @Transactional
-    public List<NotificationResponse> getNotifications(Parent parent) {
-        Pageable pageable = PageRequest.of(0, Integer.MAX_VALUE);
-        return notificationRepository.findByParentId(parent.getId(), pageable)
-                .stream()
+    public CursorResponse<NotificationResponse> getNotifications(Parent parent, Long cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        List<Notification> notifications;
+
+        if (cursor == null) {
+            notifications = notificationRepository.findByParentIdOrderByIdDesc(parent.getId(), pageable);
+        } else {
+            notifications = notificationRepository.findByParentIdAndIdLessThanOrderByIdDesc(parent.getId(), cursor, pageable);
+        }
+
+        List<NotificationResponse> content = notifications.stream()
                 .map(NotificationConverter::toResponse)
                 .toList();
+
+        Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getNotificationId();
+        boolean hasNext = notifications.size() == size;
+
+        return new CursorResponse<>(content, hasNext ? nextCursor : null, hasNext);
     }
 
     @Override
@@ -50,23 +61,24 @@ public class NotificationServiceImpl implements NotificationService {
         notification.markAsRead();
     }
 
-    @Override
+    // 직접 파라미터 전달 방식
     @Transactional
-    public void createNotification(Parent parent, NotificationRequest request) {
-        Child child = parent.getParentChild().stream()
-                .map(ParentChild::getChild)
-                .filter(c -> c.getId().equals(request.getChildId()))
-                .findFirst()
-                .orElseThrow(() -> new NotificationException(NotificationErrorCode.UNAUTHORIZED_ACCESS));
+    public void createNotification(Parent parent, Child child, String message, Float fever, Float temperature, Float humidity) {
+        Notification notification = NotificationConverter.from(
+                parent,
+                child,
+                message,
+                fever,
+                temperature,
+                humidity
+        );
 
-        // ✅ 수정됨: Converter 사용
-        Notification notification = NotificationConverter.fromRequest(request, parent, child);
         notificationRepository.save(notification);
 
         List<FcmToken> tokens = parent.getFcmTokens();
         if (!tokens.isEmpty()) {
             String token = tokens.get(0).getToken();
-            fcmService.sendNotification(token, "케어 알림", request.getMessage());
+            fcmService.sendNotification(token, "케어 알림", message);
         } else {
             System.out.println("⚠️ FCM 토큰 없음 - 푸시 생략");
         }

--- a/src/main/java/final_project/momeasy/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,74 @@
+package final_project.momeasy.domain.notification.service;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.notification.converter.NotificationConverter;
+import final_project.momeasy.domain.notification.dto.NotificationRequest;
+import final_project.momeasy.domain.notification.dto.NotificationResponse;
+import final_project.momeasy.domain.notification.entity.Notification;
+import final_project.momeasy.domain.notification.exception.NotificationErrorCode;
+import final_project.momeasy.domain.notification.exception.NotificationException;
+import final_project.momeasy.domain.notification.repository.NotificationRepository;
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.parent.entity.ParentChild;
+import final_project.momeasy.global.fcm.entity.FcmToken;
+import final_project.momeasy.global.fcm.service.FcmService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final FcmService fcmService;
+
+    @Override
+    @Transactional
+    public List<NotificationResponse> getNotifications(Parent parent) {
+        Pageable pageable = PageRequest.of(0, Integer.MAX_VALUE);
+        return notificationRepository.findByParentId(parent.getId(), pageable)
+                .stream()
+                .map(NotificationConverter::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Parent parent, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOT_FOUND));
+
+        if (!notification.getParent().getId().equals(parent.getId())) {
+            throw new NotificationException(NotificationErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        notification.markAsRead();
+    }
+
+    @Override
+    @Transactional
+    public void createNotification(Parent parent, NotificationRequest request) {
+        Child child = parent.getParentChild().stream()
+                .map(ParentChild::getChild)
+                .filter(c -> c.getId().equals(request.getChildId()))
+                .findFirst()
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.UNAUTHORIZED_ACCESS));
+
+        // ✅ 수정됨: Converter 사용
+        Notification notification = NotificationConverter.fromRequest(request, parent, child);
+        notificationRepository.save(notification);
+
+        List<FcmToken> tokens = parent.getFcmTokens();
+        if (!tokens.isEmpty()) {
+            String token = tokens.get(0).getToken();
+            fcmService.sendNotification(token, "케어 알림", request.getMessage());
+        } else {
+            System.out.println("⚠️ FCM 토큰 없음 - 푸시 생략");
+        }
+    }
+}

--- a/src/main/java/final_project/momeasy/global/apiPayload/CursorResponse.java
+++ b/src/main/java/final_project/momeasy/global/apiPayload/CursorResponse.java
@@ -1,0 +1,14 @@
+package final_project.momeasy.global.apiPayload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CursorResponse<T> {
+    private List<T> content;
+    private Long nextCursor;  // 마지막 알림 ID
+    private boolean hasNext;
+}


### PR DESCRIPTION
## 🔘Part

- [x] Notification 도메인 기능 구현

  <br/>
## ➕ 이슈 링크

- #133 
- #134 
- #135 

<br/>

## 🔎 작업 내용

- Notification 엔티티 및 NotificationType enum(CARE) 정의
- NotificationRequest, NotificationResponse DTO 구현
- NotificationConverter로 DTO ↔ Entity 변환 분리
- NotificationRepository 커스텀 메서드 추가
- NotificationService / ServiceImpl 구현
  - 알림 생성, 조회, 읽음 처리 기능 포함
  - FCM 푸시 전송 로직 기본 적용
- NotificationException 및 ErrorCode 작성
- NotificationController 구현
  - @AuthParent 인증 주입
  - Swagger @Operation(summary) 적용
  - CustomResponse 응답 포맷 사용

  <br/>

## 참고사항

- NotificationType은 Care(체온, 온습도)로 통합 관리 합니다.
- FcmToken 구현(ServiceImpl 부분)은 지환님과 추후에 상의해서 Refactor 하겠습니다.
