### PR TITLE
🐛 [FIX] 아이 정보 수정 시 DB 연관관계 명시적 삭제 처리

### DIFF
--- a/src/main/java/final_project/momeasy/domain/child/repository/ChildIllnessRepository.java
+++ b/src/main/java/final_project/momeasy/domain/child/repository/ChildIllnessRepository.java
@@ -1,0 +1,15 @@
+package final_project.momeasy.domain.child.repository;
+
+import final_project.momeasy.domain.child.entity.Child;
+import final_project.momeasy.domain.child.entity.ChildIllness;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChildIllnessRepository extends JpaRepository<ChildIllness, Long> {
+
+    @Modifying
+    @Query("DELETE FROM ChildIllness ci WHERE ci.child = :child")
+    void deleteByChild(@Param("child")Child child);
+}

--- a/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandServiceImpl.java
@@ -7,6 +7,7 @@ import final_project.momeasy.domain.child.dto.response.ChildResponseDTO;
 import final_project.momeasy.domain.child.entity.Child;
 import final_project.momeasy.domain.child.exception.ChildErrorCode;
 import final_project.momeasy.domain.child.exception.ChildException;
+import final_project.momeasy.domain.child.repository.ChildIllnessRepository;
 import final_project.momeasy.domain.child.repository.ChildRepository;
 import final_project.momeasy.domain.illness.entity.Illness;
 import final_project.momeasy.domain.illness.repository.IllnessRepository;
@@ -26,6 +27,7 @@ public class ChildCommandServiceImpl implements ChildCommandService {
     private final ChildRepository childRepository;
     private final ParentRepository parentRepository;
     private final IllnessRepository illnessRepository;
+    private final ChildIllnessRepository childIllnessRepository;
 
     @Override
     public ChildResponseDTO.ChildCreateResponseDTO createChild(ChildRequestDTO.ChildCreateRequestDTO dto, Long parentId) {
@@ -81,9 +83,12 @@ public class ChildCommandServiceImpl implements ChildCommandService {
         // update
         child.update(dto);
 
-        child.getChildIllnesses().clear(); // 기존 연관관계 제거
+        // 기존 연관관계 제거
+        childIllnessRepository.deleteByChild(child);
+        // 영속성 컨텍스트에서 연관관계 삭제
+        child.getChildIllnesses().clear();
 
-        // child-illness 연관관계 설정
+        // child-illness 연관관계 >새롭게< 설정
         for (IllnessType illnessType : dto.illnessTypes()) {
             Illness illness = illnessRepository.findByIllnessType(illnessType)
                     .orElseGet(() -> illnessRepository.save(


### PR DESCRIPTION
## 🔘Part

- [x] DB 연관관계 명시적 삭제

  <br/>
## ➕ 이슈 링크

- #70 

<br/>

## 🔎 작업 내용

- 메모리상 연관관계만 제거되던 기존 코드에서 중간 테이블도 명시적으로 삭제하도록 함 !
- 이제 아이 정보 수정 잘 됩니다 😎 @choi0510 
  <br/>
