### PR TITLE
✨ [FEAT] Setting 도메인 구현 및 Parent 연동 알림 설정 기능 추가

### DIFF
--- a/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
+++ b/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
@@ -72,11 +72,11 @@ public class Parent extends BaseEntity {
     @Builder.Default
     private List<Calendar> calendars = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent", cascade = CascadeType.ALL)
     @Builder.Default
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "parent", cascade = CascadeType.ALL)
     private Setting setting;
 
     // 연관 관계 메서드

--- a/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
+++ b/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
@@ -9,6 +9,7 @@ import final_project.momeasy.domain.home_cam.entity.Homecam;
 import final_project.momeasy.domain.notification.entity.Notification;
 import final_project.momeasy.domain.setting.entity.Setting;
 import final_project.momeasy.global.entity.BaseEntity;
+import final_project.momeasy.global.fcm.entity.FcmToken;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -71,7 +72,11 @@ public class Parent extends BaseEntity {
     @Builder.Default
     private List<Calendar> calendars = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY,mappedBy = "parent")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<FcmToken> fcmTokens = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private Setting setting;
 
     // 연관 관계 메서드
@@ -90,6 +95,11 @@ public class Parent extends BaseEntity {
         setting.setParent(this);
     }
 
+    public void addFcmToken(FcmToken token) {
+        this.fcmTokens.add(token);
+        token.setParent(this);
+    }
+
     // soft delete
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
@@ -104,5 +114,4 @@ public class Parent extends BaseEntity {
     public void undoDelete() {
         this.deletedAt = null;
     }
-
 }

--- a/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/parent/service/command/ParentCommandServiceImpl.java
@@ -7,6 +7,7 @@ import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.parent.exception.ParentErrorCode;
 import final_project.momeasy.domain.parent.exception.ParentException;
 import final_project.momeasy.domain.parent.repository.ParentRepository;
+import final_project.momeasy.domain.setting.entity.Setting;
 import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeErrorCode;
 import final_project.momeasy.global.util.mail.verification.exception.VerificationCodeException;
 import final_project.momeasy.global.util.mail.verification.service.VerificationCodeService;
@@ -38,6 +39,10 @@ public class ParentCommandServiceImpl implements ParentCommandService {
 
         // DTO -> Parent
         Parent parent = ParentConverter.toParent(parentCreateRequestDTO, passwordEncoder);
+
+        // 기본 알림 설정 생성 및 연동
+        Setting setting = Setting.createDefault();
+        parent.setSetting(setting);
 
         // DB에 저장
         parentRepository.save(parent);

--- a/src/main/java/final_project/momeasy/domain/setting/controller/SettingController.java
+++ b/src/main/java/final_project/momeasy/domain/setting/controller/SettingController.java
@@ -1,0 +1,34 @@
+package final_project.momeasy.domain.setting.controller;
+
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.setting.dto.SettingRequest;
+import final_project.momeasy.domain.setting.dto.SettingResponse;
+import final_project.momeasy.domain.setting.service.SettingService;
+import final_project.momeasy.global.apiPayload.CustomResponse;
+import final_project.momeasy.global.security.annotation.AuthParent;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/settings")
+@RequiredArgsConstructor
+public class SettingController {
+
+    private final SettingService settingService;
+
+    @Operation(summary = "부모의 알림 설정 조회")
+    @GetMapping
+    public CustomResponse<SettingResponse> getSettings(@AuthParent Parent parent) {
+        SettingResponse response = settingService.getSetting(parent);
+        return CustomResponse.onSuccess(HttpStatus.OK, response);
+    }
+
+    @Operation(summary = "부모의 알림 설정 변경")
+    @PatchMapping
+    public CustomResponse<Void> updateSettings(@AuthParent Parent parent, @RequestBody SettingRequest request) {
+        settingService.updateSetting(parent, request);
+        return CustomResponse.onSuccess(HttpStatus.OK, null);
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/setting/converter/SettingConverter.java
+++ b/src/main/java/final_project/momeasy/domain/setting/converter/SettingConverter.java
@@ -1,0 +1,26 @@
+package final_project.momeasy.domain.setting.converter;
+
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.setting.dto.SettingRequest;
+import final_project.momeasy.domain.setting.dto.SettingResponse;
+import final_project.momeasy.domain.setting.entity.Setting;
+
+public class SettingConverter {
+
+    public static Setting toEntity(SettingRequest request, Parent parent) {
+        return Setting.builder()
+                .all_alarm(request.getAllAlarm())
+                .care_alarm(request.getCareAlarm())
+                .marketing_alarm(request.getMarketingAlarm())
+                .parent(parent)
+                .build();
+    }
+
+    public static SettingResponse toResponse(Setting setting) {
+        return SettingResponse.builder()
+                .allAlarm(setting.getAll_alarm())
+                .careAlarm(setting.getCare_alarm())
+                .marketingAlarm(setting.getMarketing_alarm())
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/setting/dto/SettingRequest.java
+++ b/src/main/java/final_project/momeasy/domain/setting/dto/SettingRequest.java
@@ -1,0 +1,10 @@
+package final_project.momeasy.domain.setting.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SettingRequest {
+    private Boolean allAlarm;
+    private Boolean careAlarm;
+    private Boolean marketingAlarm;
+}

--- a/src/main/java/final_project/momeasy/domain/setting/dto/SettingResponse.java
+++ b/src/main/java/final_project/momeasy/domain/setting/dto/SettingResponse.java
@@ -1,0 +1,12 @@
+package final_project.momeasy.domain.setting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SettingResponse {
+    private Boolean allAlarm;
+    private Boolean careAlarm;
+    private Boolean marketingAlarm;
+}

--- a/src/main/java/final_project/momeasy/domain/setting/entity/Setting.java
+++ b/src/main/java/final_project/momeasy/domain/setting/entity/Setting.java
@@ -10,7 +10,9 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Setting {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
@@ -22,11 +24,34 @@ public class Setting {
     @Column(nullable = false)
     private Boolean marketing_alarm;
 
-    @OneToOne(fetch =FetchType.LAZY,cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id", nullable = false)
     private Parent parent;
 
+    // 연관관계 설정
     public void setParent(Parent parent) {
         this.parent = parent;
+    }
+
+    // 개별 설정 setter
+    public void setAll_alarm(Boolean all_alarm) {
+        this.all_alarm = all_alarm;
+    }
+
+    public void setCare_alarm(Boolean care_alarm) {
+        this.care_alarm = care_alarm;
+    }
+
+    public void setMarketing_alarm(Boolean marketing_alarm) {
+        this.marketing_alarm = marketing_alarm;
+    }
+
+    // 기본 설정 생성
+    public static Setting createDefault() {
+        return Setting.builder()
+                .all_alarm(true)
+                .care_alarm(true)
+                .marketing_alarm(true)
+                .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/setting/repository/SettingRepository.java
+++ b/src/main/java/final_project/momeasy/domain/setting/repository/SettingRepository.java
@@ -2,10 +2,10 @@ package final_project.momeasy.domain.setting.repository;
 
 import final_project.momeasy.domain.setting.entity.Setting;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface SettingRepository extends JpaRepository<Setting, Long> {
+
     Optional<Setting> findByParentId(Long parentId);
 }

--- a/src/main/java/final_project/momeasy/domain/setting/service/SettingService.java
+++ b/src/main/java/final_project/momeasy/domain/setting/service/SettingService.java
@@ -1,0 +1,12 @@
+package final_project.momeasy.domain.setting.service;
+
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.setting.dto.SettingRequest;
+import final_project.momeasy.domain.setting.dto.SettingResponse;
+
+public interface SettingService {
+
+    SettingResponse getSetting(Parent parent);
+
+    void updateSetting(Parent parent, SettingRequest request);
+}

--- a/src/main/java/final_project/momeasy/domain/setting/service/SettingServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/setting/service/SettingServiceImpl.java
@@ -1,0 +1,47 @@
+package final_project.momeasy.domain.setting.service;
+
+import final_project.momeasy.domain.parent.entity.Parent;
+import final_project.momeasy.domain.setting.converter.SettingConverter;
+import final_project.momeasy.domain.setting.dto.SettingRequest;
+import final_project.momeasy.domain.setting.dto.SettingResponse;
+import final_project.momeasy.domain.setting.entity.Setting;
+import final_project.momeasy.domain.setting.exception.SettingErrorCode;
+import final_project.momeasy.domain.setting.exception.SettingException;
+import final_project.momeasy.domain.setting.repository.SettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SettingServiceImpl implements SettingService {
+
+    private final SettingRepository settingRepository;
+
+    @Override
+    public SettingResponse getSetting(Parent parent) {
+        Setting setting = settingRepository.findByParentId(parent.getId())
+                .orElseThrow(() -> new SettingException(SettingErrorCode.NOT_FOUND));
+
+        return SettingConverter.toResponse(setting);
+    }
+
+    @Override
+    public void updateSetting(Parent parent, SettingRequest request) {
+        Setting setting = settingRepository.findByParentId(parent.getId())
+                .orElseThrow(() -> new SettingException(SettingErrorCode.NOT_FOUND));
+
+        if (Boolean.FALSE.equals(request.getAllAlarm())) {
+            // 전체 알림 OFF → 나머지도 OFF
+            setting.setAll_alarm(false);
+            setting.setCare_alarm(false);
+            setting.setMarketing_alarm(false);
+        } else {
+            // 전체 알림 ON → 하위 설정 반영
+            setting.setAll_alarm(true);
+            setting.setCare_alarm(request.getCareAlarm());
+            setting.setMarketing_alarm(request.getMarketingAlarm());
+        }
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] Setting 도메인 구현 및 Parent 연동 알림 설정 기능 추가

  <br/>
## ➕ 이슈 링크

- #147
- #148
- #149 
- #150 
- #151 

<br/>

## 🔎 작업 내용

- Setting 엔티티 생성 및 Parent와 @OneToOne 양방향 연관관계 설정
- 회원가입 시 Setting.createDefault()를 생성하여 registerSetting()으로 연동
- parentRepository.save()로 알림 설정 자동 저장 (cascade 처리)
- 알림 설정 조회 및 수정 API 구현
     -> 전체 알림 OFF 시 케어/마케팅 알림도 자동 OFF 처리


- (참고) Parent 엔티티 파일에 fcmToken 기본 설정이 같이 구현 돼있습니다.
  <br/>

