### PR TITLE
🔨 [REFACTOR] 아이 생성/추가 로직과 아이 프로필 이미지 추가 로직 분리

### DIFF
--- a/src/main/java/final_project/momeasy/domain/child/controller/ChildController.java
+++ b/src/main/java/final_project/momeasy/domain/child/controller/ChildController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -65,4 +66,13 @@ public class ChildController {
         return CustomResponse.onSuccess(HttpStatus.OK, childQueryService.getChildren(parent));
     }
 
+    @PatchMapping("/{childId}/profile-image")
+    public CustomResponse<?> uploadChildProfileImage(
+            @PathVariable Long childId,
+            @RequestPart MultipartFile profileImage,
+            @AuthParent Parent parent
+            ) throws IOException {
+        String profileUrl = childCommandService.updateChildProfileImage(childId, parent, profileImage);
+        return CustomResponse.onSuccess(HttpStatus.OK, profileUrl);
+    }
 }

--- a/src/main/java/final_project/momeasy/domain/child/controller/ChildController.java
+++ b/src/main/java/final_project/momeasy/domain/child/controller/ChildController.java
@@ -29,11 +29,10 @@ public class ChildController {
     @Operation(summary = "아이 추가")
     @PostMapping
     public CustomResponse<ChildResponseDTO.ChildCreateResponseDTO> createChild(
-            @RequestPart("dto") ChildRequestDTO.ChildCreateRequestDTO createDTO,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @RequestBody ChildRequestDTO.ChildCreateRequestDTO createDTO,
             @AuthParent Parent parent) {
         return CustomResponse.onSuccess(
-                HttpStatus.CREATED, childCommandService.createChild(createDTO, profileImage, parent.getId()));
+                HttpStatus.CREATED, childCommandService.createChild(createDTO, parent.getId()));
     }
 
     @Operation(summary = "아이 삭제")
@@ -47,10 +46,9 @@ public class ChildController {
     @PatchMapping("/{childId}")
     public CustomResponse<String> updateChild(
             @PathVariable Long childId,
-            @RequestPart("dto") ChildRequestDTO.ChildUpdateRequestDTO updateDTO,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @RequestBody ChildRequestDTO.ChildUpdateRequestDTO updateDTO,
             @AuthParent Parent parent) {
-        childCommandService.updateChild(childId, parent, updateDTO, profileImage);
+        childCommandService.updateChild(childId, parent, updateDTO);
         return CustomResponse.onSuccess(HttpStatus.OK, "아이 정보 수정 완료");
     }
 

--- a/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandService.java
+++ b/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandService.java
@@ -5,6 +5,8 @@ import final_project.momeasy.domain.child.dto.response.ChildResponseDTO;
 import final_project.momeasy.domain.parent.entity.Parent;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 public interface ChildCommandService {
 
     ChildResponseDTO.ChildCreateResponseDTO createChild(ChildRequestDTO.ChildCreateRequestDTO dto, MultipartFile profileImage, Long parentId);
@@ -12,4 +14,6 @@ public interface ChildCommandService {
     void deleteChild(Long childId, Parent parent);
 
     void updateChild(Long childId, Parent parent, ChildRequestDTO.ChildUpdateRequestDTO dto, MultipartFile profileImage);
+
+    String updateChildProfileImage(Long childId, Parent parent, MultipartFile profileImage) throws IOException;
 }

--- a/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandService.java
+++ b/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandService.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 public interface ChildCommandService {
 
-    ChildResponseDTO.ChildCreateResponseDTO createChild(ChildRequestDTO.ChildCreateRequestDTO dto, MultipartFile profileImage, Long parentId);
+    ChildResponseDTO.ChildCreateResponseDTO createChild(ChildRequestDTO.ChildCreateRequestDTO dto, Long parentId);
 
     void deleteChild(Long childId, Parent parent);
 
-    void updateChild(Long childId, Parent parent, ChildRequestDTO.ChildUpdateRequestDTO dto, MultipartFile profileImage);
+    void updateChild(Long childId, Parent parent, ChildRequestDTO.ChildUpdateRequestDTO dto);
 
     String updateChildProfileImage(Long childId, Parent parent, MultipartFile profileImage) throws IOException;
 }

--- a/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandServiceImpl.java
@@ -37,7 +37,6 @@ public class ChildCommandServiceImpl implements ChildCommandService {
     @Override
     public ChildResponseDTO.ChildCreateResponseDTO createChild(
             ChildRequestDTO.ChildCreateRequestDTO dto,
-            MultipartFile profileImage,
             Long parentId) {
 
         Parent parent = parentRepository.findById(parentId)
@@ -46,8 +45,6 @@ public class ChildCommandServiceImpl implements ChildCommandService {
         Child child = ChildConverter.toChild(dto);
 
         // TODO: 아이 중복 추가 예외 처리
-
-        uploadAndSetProfileImage(child, profileImage);
 
         childRepository.save(child);
 
@@ -85,8 +82,8 @@ public class ChildCommandServiceImpl implements ChildCommandService {
     public void updateChild(
             Long childId,
             Parent parent,
-            ChildRequestDTO.ChildUpdateRequestDTO dto,
-            MultipartFile profileImage) {
+            ChildRequestDTO.ChildUpdateRequestDTO dto
+    ) {
         Child child = childRepository.findById(childId)
                 .orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
 
@@ -96,9 +93,6 @@ public class ChildCommandServiceImpl implements ChildCommandService {
 
         // update
         child.update(dto);
-
-        // update profile image
-        uploadAndSetProfileImage(child, profileImage);
 
         // 기존 연관관계 제거
         childIllnessRepository.deleteByChild(child);

--- a/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/child/service/command/ChildCommandServiceImpl.java
@@ -119,19 +119,27 @@ public class ChildCommandServiceImpl implements ChildCommandService {
 
     }
 
-    // 이미지 업로드 메서드
-    private void uploadAndSetProfileImage(Child child, MultipartFile profileImage) {
-        if (profileImage == null || profileImage.isEmpty()) {
-            return; // 이미지 추가를 안 했을 경우 아무것도 안 하고 넘어감
+    @Override
+    public String updateChildProfileImage(Long childId, Parent parent, MultipartFile profileImage) throws IOException {
+        Child child = childRepository.findById(childId)
+                .orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
+
+        if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
+            throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 기존 이미지 있으면 삭제
+        if (child.getProfileImage() != null) {
+            s3Uploader.delete(child.getProfileImage());
         }
 
         // 새로운 이미지 업로드
-        try {
-            String fileName = s3Uploader.upload(profileImage, "profile");
-            child.updateProfileImage(fileName);
-        } catch (IOException e) {
-            throw new ChildException(ChildErrorCode.INTERNAL_ERROR);
-        }
+        String fileName = s3Uploader.upload(profileImage, "profile");
+        child.updateProfileImage(fileName);
+
+        childRepository.save(child);
+
+        return s3Uploader.getPresignedUrl(fileName);
 
     }
 }

--- a/src/main/java/final_project/momeasy/domain/child/service/query/ChildQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/child/service/query/ChildQueryServiceImpl.java
@@ -32,7 +32,7 @@ public class ChildQueryServiceImpl implements ChildQueryService {
             throw new ChildException(ChildErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        String profileImagePath = parent.getProfileImage();
+        String profileImagePath = child.getProfileImage();
         String profileImageUrl = (profileImagePath != null)
                 ? s3Uploader.getPresignedUrl(profileImagePath)
                 : null;
@@ -46,7 +46,7 @@ public class ChildQueryServiceImpl implements ChildQueryService {
 
         return children.stream()
                 .map(child -> {
-                    String profileImagePath = parent.getProfileImage();
+                    String profileImagePath = child.getProfileImage();
                     String profileImageUrl = (profileImagePath != null)
                             ? s3Uploader.getPresignedUrl(profileImagePath)
                             : null;


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크
- #160 

<br/>

## 🔎 작업 내용

- 기존 코드에서 아이 조회인데 부모 프로필 이미지를 조회하도록 했더라고요 .. 수정했습니다 20afc8657805bf230344602e7f6a047c6fa64bfd
- @choi0510 강민쓰가 요청해주신대로 프로필 이미지 업데이트는 Form-Data 방식으로, 아이 생성 및 수정 로직은 JSON 문자열로 할 수 있게 따로 분리했습니다아 5b8f0a40517b1cfd3fd8a98e09008bc5ba3a006e 01ce14183bb1809750177220202f8b203744f13c
테스트 결과 작동 잘 됩니다 😎

<br/>
