### PR TITLE
🐛 [FIX] recordDate를 `schedule_date`로 매핑

### DIFF
--- a/src/main/java/final_project/momeasy/domain/calendar/entity/Calendar.java
+++ b/src/main/java/final_project/momeasy/domain/calendar/entity/Calendar.java
@@ -11,14 +11,15 @@ import java.time.LocalDate;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE) // 외부에서 무분별한 생성 방지
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Calendar extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    // 자바 필드명은 recordDate 유지, DB 컬럼만 schedule_date로 매핑
+    @Column(name = "schedule_date", nullable = false)
     private LocalDate recordDate;
 
     @Column(nullable = false)

--- a/src/main/java/final_project/momeasy/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/final_project/momeasy/domain/calendar/repository/CalendarRepository.java
@@ -3,22 +3,12 @@ package final_project.momeasy.domain.calendar.repository;
 import final_project.momeasy.domain.calendar.entity.Calendar;
 import final_project.momeasy.domain.parent.entity.Parent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
-
-    // 날짜 + 부모 기준
-    @Query("SELECT c FROM Calendar c WHERE c.recordDate = :date AND c.parent = :parent")
-    List<Calendar> findByRecordDateAndParent(@Param("date") LocalDate date,
-                                               @Param("parent") Parent parent);
-
-    // 제목에 키워드 포함 (대소문자 무시)
+    List<Calendar> findByRecordDateAndParent(LocalDate recordDate, Parent parent);
     List<Calendar> findByTitleContainingIgnoreCase(String keyword);
-
-    // 부모로 전체 조회
     List<Calendar> findByParent(Parent parent);
 }

--- a/src/main/java/final_project/momeasy/domain/calendar/service/CalendarQueryService.java
+++ b/src/main/java/final_project/momeasy/domain/calendar/service/CalendarQueryService.java
@@ -19,21 +19,18 @@ public class CalendarQueryService {
 
     private final CalendarRepository calendarRepository;
 
-    // 1. 일정 단건 조회
     public CalendarResponseDto getCalendar(Long id) {
         Calendar calendar = calendarRepository.findById(id)
                 .orElseThrow(() -> new CalendarException(CalendarErrorCode.NOT_FOUND));
         return CalendarConverter.toResponseDto(calendar);
     }
 
-    // 2. 내 전체 일정 조회
     public List<CalendarResponseDto> getCalendarsByParent(Parent parent) {
         return calendarRepository.findByParent(parent).stream()
                 .map(CalendarConverter::toResponseDto)
                 .toList();
     }
 
-    // 3. 날짜 기반 일정 조회
     public List<CalendarResponseDto> getCalendarsByDate(Parent parent, LocalDate date) {
         List<Calendar> calendars = calendarRepository.findByRecordDateAndParent(date, parent);
         return calendars.stream()
@@ -41,7 +38,6 @@ public class CalendarQueryService {
                 .toList();
     }
 
-    // 4. 키워드 기반 일정 검색
     public List<CalendarResponseDto> searchCalendars(Parent parent, String keyword) {
         List<Calendar> calendars = calendarRepository.findByTitleContainingIgnoreCase(keyword).stream()
                 .filter(c -> c.getParent().getId().equals(parent.getId()))

--- a/src/main/java/final_project/momeasy/domain/calendar/service/CalendarService.java
+++ b/src/main/java/final_project/momeasy/domain/calendar/service/CalendarService.java
@@ -15,19 +15,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-
 public class CalendarService {
 
     private final CalendarRepository calendarRepository;
 
-    // 1. 일정 추가
     public CalendarResponseDto createCalendar(CalendarRequestDto requestDto, Parent parent) {
         Calendar calendar = CalendarConverter.toEntity(requestDto, parent);
         Calendar saved = calendarRepository.save(calendar);
         return CalendarConverter.toResponseDto(saved);
     }
 
-    // 2. 일정 수정
     public CalendarResponseDto updateCalendar(Long id, CalendarRequestDto requestDto, Parent parent) {
         Calendar calendar = calendarRepository.findById(id)
                 .orElseThrow(() -> new CalendarException(CalendarErrorCode.NOT_FOUND));
@@ -45,7 +42,6 @@ public class CalendarService {
         return CalendarConverter.toResponseDto(calendar);
     }
 
-    // 3. 일정 삭제
     public void deleteCalendar(Long id, Parent parent) {
         Calendar calendar = calendarRepository.findById(id)
                 .orElseThrow(() -> new CalendarException(CalendarErrorCode.NOT_FOUND));


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

- #166 

<br/>

## 🔎 작업 내용

- Calendar 엔티티의 recordDate 필드를 DB 컬럼 schedule_date로 매핑 수정

- 캘린더 생성 시 발생하던 500 에러(Field 'schedule_date' doesn't have a default value) 해결

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
