### PR TITLE
🔨 [REFACTOR] 로컬/소셜 로그인 응답 통일

### DIFF
--- a/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
+++ b/src/main/java/final_project/momeasy/global/auth/controller/AuthController.java
@@ -59,19 +59,9 @@ public class AuthController {
     @Operation(summary = "소셜 로그인 (KAKAO, NAVER)")
     @PostMapping("/social-login")
     public CustomResponse<OAuthResponseDTO.OAuthLoginResponseDTO> socialLogin(
-            @RequestBody OAuthRequestDTO.OAuthLoginRequestDTO requestDTO,
-            HttpServletResponse response) {
+            @RequestBody OAuthRequestDTO.OAuthLoginRequestDTO reqDTO) {
 
-        OAuthResponseDTO.OAuthLoginResponseDTO responseDTO = oAuthLoginService.login(requestDTO);
-
-        String email = jwtUtil.getEmail(responseDTO.accessToken());
-        String refreshToken = tokenService.findByEmail(email)
-                .orElseThrow(() -> new JwtException(JwtErrorCode.MISSING_TOKEN))
-                .getRefreshToken();
-
-        CookieUtil.addRefreshTokenToCookie(response, refreshToken);
-
-        return CustomResponse.onSuccess(responseDTO);
+        return CustomResponse.onSuccess(oAuthLoginService.login(reqDTO));
     }
 
     @Operation(summary = "비밀번호 재설정 (임시 비밀번호 메일 발급)")

--- a/src/main/java/final_project/momeasy/global/auth/dto/response/OAuthResponseDTO.java
+++ b/src/main/java/final_project/momeasy/global/auth/dto/response/OAuthResponseDTO.java
@@ -1,8 +1,13 @@
 package final_project.momeasy.global.auth.dto.response;
 
+import lombok.Builder;
+
 public class OAuthResponseDTO {
+
+    @Builder
     public record OAuthLoginResponseDTO(
-            String accessToken
+            String accessToken,
+            String refreshToken
     ) {
     }
 }

--- a/src/main/java/final_project/momeasy/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/final_project/momeasy/global/auth/exception/AuthErrorCode.java
@@ -19,6 +19,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     OAUTH_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "AUTH400_2", "소셜 사용자 정보 조회에 실패했습니다."),
     OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH400_3", "이메일 정보를 찾을 수 없습니다."),
     OAUTH_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "AUTH400_4", "로그인에 실패했습니다."),
+    UNSUPPORTED_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH400_5", "지원하지 않는 소셜 로그인입니다."),
     ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, "AUTH403", "계정이 비활성화 되었습니다."),
     ACCOUNT_LOCKED(HttpStatus.LOCKED, "AUTH423", "계정이 잠금 상태입니다."),
     LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500", "인증에 실패했습니다.");

--- a/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
@@ -8,6 +8,8 @@ import final_project.momeasy.global.auth.client.SocialOAuthApiClient;
 import final_project.momeasy.global.auth.dto.ParentProfile;
 import final_project.momeasy.global.auth.dto.request.OAuthRequestDTO;
 import final_project.momeasy.global.auth.dto.response.OAuthResponseDTO;
+import final_project.momeasy.global.auth.exception.AuthErrorCode;
+import final_project.momeasy.global.auth.exception.AuthException;
 import final_project.momeasy.global.security.CustomUserDetails;
 import final_project.momeasy.global.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +34,7 @@ public class OAuthLoginServiceImpl implements OAuthLoginService {
         SocialOAuthApiClient client = socialOAuthApiClients.stream()
                 .filter(c -> c.supports(oAuthLoginRequestDTO.provider()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + oAuthLoginRequestDTO.provider()));
+                .orElseThrow(() -> new AuthException(AuthErrorCode.UNSUPPORTED_SOCIAL_PROVIDER));
 
         // 사용자 정보 요청
         ParentProfile profile = client.fetchProfile(oAuthLoginRequestDTO.accessToken());

--- a/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/auth/service/OAuthLoginServiceImpl.java
@@ -50,11 +50,17 @@ public class OAuthLoginServiceImpl implements OAuthLoginService {
 
         // JWT 발급
         CustomUserDetails userDetails = new CustomUserDetails(parent);
+
+        log.info("[ OAuthLoginServiceImpl > JwtUtil ] AccessToken 발급");
         String accessJwt = jwtUtil.generateJwtAccessToken(userDetails);
+        log.info("[ OAuthLoginServiceImpl > JwtUtil ] RefreshToken 발급");
         String refreshJwt = jwtUtil.generateRefreshToken(userDetails);
 
         tokenService.saveOrUpdate(parent.getEmail(), refreshJwt);
 
-        return new OAuthResponseDTO.OAuthLoginResponseDTO(accessJwt);
+        return OAuthResponseDTO.OAuthLoginResponseDTO.builder()
+                .accessToken(accessJwt)
+                .refreshToken(refreshJwt)
+                .build();
     }
 }

--- a/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
+++ b/src/main/java/final_project/momeasy/global/config/SecurityConfig.java
@@ -73,7 +73,11 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/swagger-resources/**",
-            "/api/auth/**",
+            "/api/auth/login",
+            "/api/auth/social-login",
+            "/api/auth/signup",
+            "/api/auth/reset-password",
+            "/api/auth/refresh",
             "/api/email/**",
             "/login/**"
     };

--- a/src/main/java/final_project/momeasy/global/security/CustomUserDetailsService.java
+++ b/src/main/java/final_project/momeasy/global/security/CustomUserDetailsService.java
@@ -2,8 +2,6 @@ package final_project.momeasy.global.security;
 
 import final_project.momeasy.common.enums.SocialType;
 import final_project.momeasy.domain.parent.entity.Parent;
-import final_project.momeasy.domain.parent.exception.ParentErrorCode;
-import final_project.momeasy.domain.parent.exception.ParentException;
 import final_project.momeasy.domain.parent.repository.ParentRepository;
 import final_project.momeasy.global.auth.exception.AuthErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +25,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         log.info("[ CustomUserDetailsService loadUserByUsername() ] email을 이용하여 user를 검색합니다.");
 
         Parent parent = parentRepository.findByEmail(email)
-                .orElseThrow(() -> new ParentException(ParentErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new UsernameNotFoundException(AuthErrorCode.WRONG_ID.getMessage()));
 
         // 소셜 로그인 유저일 경우 로그인 불가 예외
         if (parent.getSocialType() != SocialType.LOCAL) {

--- a/src/main/java/final_project/momeasy/global/security/dto/response/LoginResponseDTO.java
+++ b/src/main/java/final_project/momeasy/global/security/dto/response/LoginResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record LoginResponseDTO(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
 }

--- a/src/main/java/final_project/momeasy/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/final_project/momeasy/global/security/filter/CustomLoginFilter.java
@@ -79,12 +79,10 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         // refresh token DB에 저장
         tokenService.saveOrUpdate(customUserDetails.getUsername(), refreshToken);
 
-        // refresh token은 쿠키로 전달
-        CookieUtil.addRefreshTokenToCookie(response, refreshToken);
-
         // Client에게 줄 Response build
         LoginResponseDTO loginResponse = LoginResponseDTO.builder()
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
 
         // Custom Response 작성

--- a/src/main/java/final_project/momeasy/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/final_project/momeasy/global/security/filter/JwtAuthorizationFilter.java
@@ -34,6 +34,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private final ParentRepository parentRepository;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String uri = request.getRequestURI();
+        return uri.startsWith("/api/auth/login")
+                || uri.startsWith("/api/auth/social-login")
+                || uri.startsWith("/api/auth/refresh")
+                || uri.equals("/api/auth/signup")
+                || uri.equals("/api/auth/reset-password");
+    }
+
+    @Override
     protected void doFilterInternal(
             @NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

- #192 
<br/>

## 🔎 작업 내용

- 소셜 로그인 관련 커스텀 에러 코드 추가 https://github.com/SMU-25/server/commit/46143e9d19bf6832db3bf456976e0c87c730c020
- 인증/인가 Filter 및 보안 정책 정리 https://github.com/SMU-25/server/commit/9598ac1f3d64e5eb8abce97343ffe9efda56dd2b
  - JwtAuthorizationFilter: login, signup, social-login, reset-password, refresh 는 shouldNotFilter로 스킵
  - SecurityConfig: /api/auth/**로 auth 관련 엔드포인트를 전체 허용하는 대신 logout 제외 나머지만 permitAll 허용
- (로컬/소셜 공통) 로그인 응답에 refresh token 추가 https://github.com/SMU-25/server/commit/4206afe86646871a3ad7c3ee7dd51fb83ee2ae7b
  - 기존에는 accessToken만 응답 바디에 포함했었는데 이제는 refreshToken도 함께 반환
- 로그인 시 Parent 에러 코드 대신 Auth 에러 코드로 통일하여 사용하도록 수정 https://github.com/SMU-25/server/commit/045781b8128b2a5953b22c2b95df3675a3fcc2bf
  <br/>

## 이미지 첨부
<img width="40%" height="40%" alt="image" src="https://github.com/user-attachments/assets/4b283454-1df1-4417-8244-c2dbae347cd1" />
<img width="40%" height="40%" alt="image" src="https://github.com/user-attachments/assets/3e2cb537-4744-46df-88ae-976f0c198b3c" />

<br/>
