### PR TITLE
🐛 [FIX] 이메일 인증 시 기존 이메일 입력하면 오류 처리

### DIFF
--- a/src/main/java/final_project/momeasy/domain/child/controller/ChildController.java
+++ b/src/main/java/final_project/momeasy/domain/child/controller/ChildController.java
@@ -64,6 +64,7 @@ public class ChildController {
         return CustomResponse.onSuccess(HttpStatus.OK, childQueryService.getChildren(parent));
     }
 
+    @Operation(summary = "아이 프로필 사진 업로드")
     @PatchMapping("/{childId}/profile-image")
     public CustomResponse<?> uploadChildProfileImage(
             @PathVariable Long childId,

--- a/src/main/java/final_project/momeasy/domain/parent/repository/ParentRepository.java
+++ b/src/main/java/final_project/momeasy/domain/parent/repository/ParentRepository.java
@@ -15,4 +15,6 @@ public interface ParentRepository extends JpaRepository<Parent, Long> {
     Optional<Parent> findByIdNotDeleted(@Param("parentId") Long id);
 
     Optional<Parent> findByEmailAndDeletedAtIsNull(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/final_project/momeasy/global/util/mail/service/MailServiceImpl.java
+++ b/src/main/java/final_project/momeasy/global/util/mail/service/MailServiceImpl.java
@@ -1,5 +1,8 @@
 package final_project.momeasy.global.util.mail.service;
 
+import final_project.momeasy.domain.parent.exception.ParentErrorCode;
+import final_project.momeasy.domain.parent.exception.ParentException;
+import final_project.momeasy.domain.parent.repository.ParentRepository;
 import final_project.momeasy.global.util.mail.verification.service.VerificationCodeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MailServiceImpl implements MailService {
 
+    private final ParentRepository parentRepository;
     private final JavaMailSender mailSender;
     private final VerificationCodeService verificationCodeService;
 
@@ -26,6 +30,11 @@ public class MailServiceImpl implements MailService {
 
     @Override
     public void sendVerificationCode(String email) {
+
+        if (parentRepository.existsByEmail(email)) {
+            throw new ParentException(ParentErrorCode.DUPLICATE_EMAIL);
+        }
+
         String code = verificationCodeService.generateAndStoreCode(email);
 
         String subject = "[맘편해] 이메일 인증 코드입니다.";


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

- #146 

<br/>

## 🔎 작업 내용

- 이메일 인증 코드 전송할 때 기존에 존재하는 이메일 입력하면 에러 발생하도록 수정 완료했습니당

  <br/>

## 이미지 첨부

요로케요
<img width="288" height="131" alt="image" src="https://github.com/user-attachments/assets/5810eb27-7305-4ec0-af0a-57ffd06fe36b" />
<br/>
