### PR TITLE
🐛 [FIX] FCM 토큰 관리 로직 개선

### DIFF
--- a/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
+++ b/src/main/java/final_project/momeasy/domain/parent/entity/Parent.java
@@ -97,7 +97,6 @@ public class Parent extends BaseEntity {
 
     public void addFcmToken(FcmToken token) {
         this.fcmTokens.add(token);
-        token.setParent(this);
     }
 
     // soft delete

--- a/src/main/java/final_project/momeasy/global/fcm/controller/FcmTokenController.java
+++ b/src/main/java/final_project/momeasy/global/fcm/controller/FcmTokenController.java
@@ -1,16 +1,16 @@
 package final_project.momeasy.global.fcm.controller;
 
+import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.global.apiPayload.CustomResponse;
 import final_project.momeasy.global.fcm.dto.FcmTokenRequest;
 import final_project.momeasy.global.fcm.service.FcmTokenService;
-import final_project.momeasy.global.security.CustomUserDetails;
 import final_project.momeasy.global.security.annotation.AuthParent;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-
 
 @RestController
 @RequestMapping("/api/fcm-token")
@@ -20,21 +20,23 @@ public class FcmTokenController {
 
     private final FcmTokenService tokenService;
 
+    @Operation(summary = "FCM 토큰 저장")
     @PostMapping
     public CustomResponse<String> saveToken(
-            @AuthParent CustomUserDetails customUserDetails,
+            @AuthParent Parent parent,
             @Valid @RequestBody FcmTokenRequest request
     ) {
-        tokenService.saveToken(customUserDetails.getParent(), request.token(), request.deviceType());
+        tokenService.saveToken(parent, request.token(), request.deviceType());
         return CustomResponse.onSuccess(HttpStatus.CREATED, "FCM 토큰 저장 완료");
     }
 
+    @Operation(summary = "FCM 토큰 삭제")
     @DeleteMapping
     public CustomResponse<String> deleteToken(
-            @AuthParent CustomUserDetails customUserDetails,
+            @AuthParent Parent parent,
             @RequestParam String token
     ) {
-        tokenService.deleteToken(customUserDetails.getParent(), token);
+        tokenService.deleteToken(parent, token);
         return CustomResponse.onSuccess(HttpStatus.OK, "FCM 토큰 삭제 완료");
     }
 }

--- a/src/main/java/final_project/momeasy/global/fcm/entity/FcmToken.java
+++ b/src/main/java/final_project/momeasy/global/fcm/entity/FcmToken.java
@@ -6,11 +6,19 @@ import final_project.momeasy.common.enums.DeviceType;
 import jakarta.persistence.*;
 import lombok.*;
 
-
 @Entity
-@Table(name = "fcm_token", indexes = {
-        @Index(name = "idx_fcm_token_parent", columnList = "parent_id")
-})
+@Table(
+        name = "fcm_token",
+        indexes = {
+                @Index(name = "idx_fcm_token_parent", columnList = "parent_id")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_parent_token",
+                        columnNames = {"parent_id", "token"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -25,18 +33,14 @@ public class FcmToken extends BaseEntity {
     @JoinColumn(name = "parent_id", nullable = false)
     private Parent parent;
 
-    @Column(nullable = false, unique = true, length = 512)
+    @Column(nullable = false, length = 512)
     private String token;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 32)
     private DeviceType deviceType;
 
-    public void setParent(Parent parent) {
-        this.parent = parent;
-    }
-
-    public void setDeviceType(DeviceType deviceType) {
+    public void updateDeviceType(DeviceType deviceType) {
         this.deviceType = deviceType;
     }
 }

--- a/src/main/java/final_project/momeasy/global/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/final_project/momeasy/global/fcm/repository/FcmTokenRepository.java
@@ -6,9 +6,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    // 토큰 단독으로 조회 (다른 parent와 중복될 수 있으니 주의)
     Optional<FcmToken> findByToken(String token);
+
+    // 특정 parent의 모든 토큰 조회
     List<FcmToken> findAllByParentId(Long parentId);
-    void deleteByToken(String token);
+
+    // parentId + token 조합으로 조회 (안전하게 특정 부모 소유 토큰만 찾을 때)
+    Optional<FcmToken> findByParentIdAndToken(Long parentId, String token);
+
+    // parentId + token 조합으로 삭제
+    void deleteByParentIdAndToken(Long parentId, String token);
+
+    // parent의 모든 토큰 삭제 (로그아웃/탈퇴 시 편리)
+    void deleteAllByParentId(Long parentId);
 }

--- a/src/main/java/final_project/momeasy/global/fcm/service/FcmService.java
+++ b/src/main/java/final_project/momeasy/global/fcm/service/FcmService.java
@@ -31,18 +31,19 @@ public class FcmService {
                 .setToken(targetToken)
                 .setNotification(Notification.builder().setTitle(title).setBody(body).build())
                 .build();
-        doSend(targetToken, message);
+        doSend(null, targetToken, message);
     }
 
     @Async
-    public void sendNotification(String targetToken, DeviceType deviceType, String title, String body, String deeplink, String type) {
+    public void sendNotification(String targetToken, DeviceType deviceType,
+                                 String title, String body, String deeplink, String type) {
         Message message = buildPerDeviceMessage(targetToken, deviceType, title, body, deeplink, type);
-        doSend(targetToken, message);
+        doSend(null, targetToken, message);
     }
 
-
     @Async
-    public void sendAnnouncementToTopic(String topic, String title, String body, String deeplink, String type) {
+    public void sendAnnouncementToTopic(String topic, String title,
+                                        String body, String deeplink, String type) {
         AndroidConfig android = AndroidConfig.builder()
                 .setPriority(AndroidConfig.Priority.HIGH)
                 .setNotification(AndroidNotification.builder()
@@ -69,10 +70,11 @@ public class FcmService {
                 .setApnsConfig(apns)
                 .build();
 
-        doSend(null, message);
+        doSend(null, null, message);
     }
 
-    private Message buildPerDeviceMessage(String token, DeviceType deviceType, String title, String body, String deeplink, String type) {
+    private Message buildPerDeviceMessage(String token, DeviceType deviceType,
+                                          String title, String body, String deeplink, String type) {
         if (deviceType == DeviceType.IOS) {
             return Message.builder()
                     .setToken(token)
@@ -96,16 +98,22 @@ public class FcmService {
         }
     }
 
-    private void doSend(String targetTokenOrNull, Message message) {
+    private void doSend(Long parentIdOrNull, String targetTokenOrNull, Message message) {
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("FCM sent: {}", response);
         } catch (FirebaseMessagingException e) {
-            MessagingErrorCode code = e.getMessagingErrorCode(); // ✅ Admin SDK 권장 방식
+            MessagingErrorCode code = e.getMessagingErrorCode();
             log.warn("FCM failed: code={}, msg={}", code, e.getMessage(), e);
 
             if (code == MessagingErrorCode.UNREGISTERED && targetTokenOrNull != null) {
-                tokenService.deleteTokenSilentlyIfExists(targetTokenOrNull);
+                if (parentIdOrNull != null) {
+                    // 특정 Parent 소유 토큰만 안전하게 삭제
+                    tokenService.deleteTokenSilentlyIfExists(parentIdOrNull, targetTokenOrNull);
+                } else {
+                    // fallback: parent 정보 없으면 기존 방식으로 삭제
+                    tokenService.deleteTokenSilentlyIfExists(targetTokenOrNull);
+                }
                 throw new FcmException(FcmErrorCode.UNREGISTERED_TOKEN);
             }
             if (code == MessagingErrorCode.INVALID_ARGUMENT) {

--- a/src/main/java/final_project/momeasy/global/fcm/service/FcmTokenService.java
+++ b/src/main/java/final_project/momeasy/global/fcm/service/FcmTokenService.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-
 import java.util.List;
 
 @Service
@@ -23,10 +22,19 @@ public class FcmTokenService {
     public void saveToken(Parent parent, String token, DeviceType deviceType) {
         tokenRepository.findByToken(token).ifPresentOrElse(
                 f -> {
-                    if (!f.getParent().getId().equals(parent.getId())) {
-                        f.setParent(parent);
+                    if (f.getParent().getId().equals(parent.getId())) {
+                        // 같은 parent + token → 업데이트
+                        f.updateDeviceType(deviceType);
+                    } else {
+                        // 다른 parent가 쓰던 토큰 → 삭제 후 새로 저장
+                        tokenRepository.delete(f);
+                        tokenRepository.flush();
+                        tokenRepository.save(FcmToken.builder()
+                                .parent(parent)
+                                .token(token)
+                                .deviceType(deviceType)
+                                .build());
                     }
-                    f.setDeviceType(deviceType);
                 },
                 () -> tokenRepository.save(
                         FcmToken.builder()
@@ -40,12 +48,8 @@ public class FcmTokenService {
 
     @Transactional
     public void deleteToken(Parent parent, String token) {
-        FcmToken f = tokenRepository.findByToken(token)
+        FcmToken f = tokenRepository.findByParentIdAndToken(parent.getId(), token)
                 .orElseThrow(() -> new FcmException(FcmErrorCode.TOKEN_NOT_FOUND));
-
-        if (!f.getParent().getId().equals(parent.getId())) {
-            throw new FcmException(FcmErrorCode.TOKEN_NOT_OWNED);
-        }
         tokenRepository.delete(f);
     }
 
@@ -54,11 +58,22 @@ public class FcmTokenService {
         tokenRepository.findByToken(token).ifPresent(tokenRepository::delete);
     }
 
+    @Transactional
+    public void deleteTokenSilentlyIfExists(Long parentId, String token) {
+        tokenRepository.findByParentIdAndToken(parentId, token)
+                .ifPresent(tokenRepository::delete);
+    }
+
     @Transactional(readOnly = true)
     public List<String> getTokenStringsByParent(Parent parent) {
         return tokenRepository.findAllByParentId(parent.getId())
                 .stream()
                 .map(FcmToken::getToken)
                 .toList();
+    }
+
+    @Transactional
+    public void deleteAllByParent(Parent parent) {
+        tokenRepository.deleteAllByParentId(parent.getId());
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

- #208 

<br/>

## 🔎 작업 내용

- FCM 토큰 관리 로직 관련 이슈 확인 및 개선 진행
- 서비스 로직을 upsert 구조로 수정하여 중복 저장 시 409 Conflict 방지
- UNREGISTERED 토큰 발생 시 DB 자동 정리 로직 추가
- 기존 token 단독 unique 제약 → (parentId, token) 조합 unique로 변경

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
