### PR TITLE
:hammer: [REFACTOR] RoomConditionQueryServiceImpl SRP 적용, 코드 분리

### DIFF
--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/AvgFever.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/AvgFever.java
@@ -16,26 +16,25 @@ public class AvgFever {
     private final FeverRecordRepository feverRecordRepository;
 
     public float getFeverAvgBy3Hour(int time, Long childId) {
-        LocalDateTime start = LocalDate.now().atTime(time,0);
+        LocalDateTime start = LocalDate.now().atTime(time, 0);
         LocalDateTime end = (time == 21)
-                ?LocalDate.now().plusDays(1).atStartOfDay()
-                :LocalDate.now().atTime(time+3,0);
-        List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndRecordStateAndCreatedAtBetween(childId, RecordState.HUMAN, start,end);
-        return (float) Math.round(
-                feverRecords.stream()
-                        .mapToDouble(FeverRecord::getFever)
-                        .average()
-                        .orElse(0.0) * 10
-        ) / 10;
+                ? LocalDate.now().plusDays(1).atStartOfDay()
+                : LocalDate.now().atTime(time + 3, 0);
+        List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndRecordStateAndCreatedAtBetween(childId, RecordState.HUMAN, start, end);
+        return AvgFever(feverRecords);
     }
 
     public float getFeverAvgByDayAndTimeRange(int day, int time1, int time2, Long childId) {
         LocalDate now = LocalDate.now().minusDays(day);
-        LocalDateTime start = now.atTime(time1,0);
+        LocalDateTime start = now.atTime(time1, 0);
         LocalDateTime end = (time2 == 24)
                 ? now.plusDays(1).atStartOfDay()
                 : now.atTime(time2, 0);
-        List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndRecordStateAndCreatedAtBetween(childId, RecordState.HUMAN, start,end);
+        List<FeverRecord> feverRecords = feverRecordRepository.findByChildIdAndRecordStateAndCreatedAtBetween(childId, RecordState.HUMAN, start, end);
+        return AvgFever(feverRecords);
+    }
+
+    private float AvgFever(List<FeverRecord> feverRecords) {
         return (float) Math.round(
                 feverRecords.stream()
                         .mapToDouble(FeverRecord::getFever)

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphGenerator.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphGenerator.java
@@ -1,0 +1,32 @@
+package final_project.momeasy.domain.fever_graph.service;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_graph.dto.FeverGraphResponseDTO;
+import final_project.momeasy.domain.fever_graph.entity.FeverGraph;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeverGraphGenerator {
+    private final AvgFever avgFever;
+
+    public FeverGraph FeverGraph(FeverReport feverReport, int dayOffset, DayRange dayRange, int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.DAY1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        FeverGraph feverGraph = FeverGraph.builder()
+                .avgFever(avg)
+                .dayRange(dayRange)
+                .build();
+        feverGraph.setFeverReport(feverReport);
+        return feverGraph;
+    }
+
+    public FeverGraphResponseDTO.FeverGraphHomecamViewDTO HomecamFeverGraph(int dayOffset, DayRange dayRange, int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.DAY1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        return FeverGraphResponseDTO.FeverGraphHomecamViewDTO.builder()
+                .avgfever(avg)
+                .dayRange(dayRange)
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/fever_graph/service/FeverGraphServiceImpl.java
@@ -23,26 +23,26 @@ import java.util.List;
 public class FeverGraphServiceImpl implements FeverGraphService {
     private final FeverGraphRepository feverGraphRepository;
     private final FeverReportRepository feverReportRepository;
-    private final AvgFever avgFever;
+    private final FeverGraphGenerator feverGraphGenerator;
 
     @Override
     public List<FeverGraph> createFeverRecordGraph(Long recordId, Parent parent, Long childId) {
-        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(() -> new FeverReportException(FeverReportErrorCode.NOT_FOUND));
 
         List<FeverGraph> feverGraphs = new ArrayList<>();
         // 범위 day1
-        for(int t = 0 ; t <24 ; t+=3){
-            feverGraphs.add(buildFeverGraph(feverReport, 0, DayRange.DAY1,t, t, childId));
+        for (int t = 0; t < 24; t += 3) {
+            feverGraphs.add(feverGraphGenerator.FeverGraph(feverReport, 0, DayRange.DAY1, t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY3,0, 6,childId));   // 새벽
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY3,6, 12,childId));  // 오전
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY3,12, 24,childId)); // 오후
+            feverGraphs.add(feverGraphGenerator.FeverGraph(feverReport, d, DayRange.DAY3, 0, 6, childId));   // 새벽
+            feverGraphs.add(feverGraphGenerator.FeverGraph(feverReport, d, DayRange.DAY3, 6, 12, childId));  // 오전
+            feverGraphs.add(feverGraphGenerator.FeverGraph(feverReport, d, DayRange.DAY3, 12, 24, childId)); // 오후
         }
         // 범위 day7
-        for(int d = 6; d>=0; d--){
-            feverGraphs.add(buildFeverGraph(feverReport, d, DayRange.DAY7,0, 24,childId));
+        for (int d = 6; d >= 0; d--) {
+            feverGraphs.add(feverGraphGenerator.FeverGraph(feverReport, d, DayRange.DAY7, 0, 24, childId));
         }
         feverGraphRepository.saveAll(feverGraphs);
         return feverGraphs;
@@ -51,37 +51,19 @@ public class FeverGraphServiceImpl implements FeverGraphService {
     @Override
     public List<FeverGraphResponseDTO.FeverGraphHomecamViewDTO> getHomeCamFeverRecordGraph(Parent parent, Long childId) {
 
-       List<FeverGraphResponseDTO.FeverGraphHomecamViewDTO> feverGraphs = new ArrayList<>();
-        for(int t = 0 ; t <24 ; t+=3){
-            feverGraphs.add(buildHomecamFeverGraph( 0, DayRange.DAY1,t, t, childId));
+        List<FeverGraphResponseDTO.FeverGraphHomecamViewDTO> feverGraphs = new ArrayList<>();
+        for (int t = 0; t < 24; t += 3) {
+            feverGraphs.add(feverGraphGenerator.HomecamFeverGraph(0, DayRange.DAY1, t, t, childId));
         }
         for (int d = 2; d >= 0; d--) {
-            feverGraphs.add(buildHomecamFeverGraph( d, DayRange.DAY3,0, 6,childId));   // 새벽
-            feverGraphs.add(buildHomecamFeverGraph( d, DayRange.DAY3,6, 12,childId));  // 오전
-            feverGraphs.add(buildHomecamFeverGraph(d, DayRange.DAY3,12, 24,childId)); // 오후
+            feverGraphs.add(feverGraphGenerator.HomecamFeverGraph(d, DayRange.DAY3, 0, 6, childId));   // 새벽
+            feverGraphs.add(feverGraphGenerator.HomecamFeverGraph(d, DayRange.DAY3, 6, 12, childId));  // 오전
+            feverGraphs.add(feverGraphGenerator.HomecamFeverGraph(d, DayRange.DAY3, 12, 24, childId)); // 오후
         }
         // 범위 day7
-        for(int d = 6; d>=0; d--){
-            feverGraphs.add(buildHomecamFeverGraph(d, DayRange.DAY7,0, 24,childId));
+        for (int d = 6; d >= 0; d--) {
+            feverGraphs.add(feverGraphGenerator.HomecamFeverGraph(d, DayRange.DAY7, 0, 24, childId));
         }
         return feverGraphs;
-    }
-
-    private FeverGraph buildFeverGraph(FeverReport feverReport, int dayOffset, DayRange dayRange ,int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.DAY1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
-        FeverGraph feverGraph = FeverGraph.builder()
-                .avgFever(avg)
-                .dayRange(dayRange)
-                .build();
-        feverGraph.setFeverReport(feverReport);
-        return feverGraph;
-    }
-
-    private FeverGraphResponseDTO.FeverGraphHomecamViewDTO buildHomecamFeverGraph(int dayOffset, DayRange dayRange ,int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.DAY1 ? avgFever.getFeverAvgBy3Hour(startHour, childId) : avgFever.getFeverAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
-        return FeverGraphResponseDTO.FeverGraphHomecamViewDTO.builder()
-                .avgfever(avg)
-                .dayRange(dayRange)
-                .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/AvgHumidity.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/AvgHumidity.java
@@ -15,26 +15,25 @@ public class AvgHumidity {
     private final RoomConditionRepository roomConditionRepository;
 
     public float getHumidityAvgBy3Hour(int time, Long childId) {
-        LocalDateTime start = LocalDate.now().atTime(time,0);
+        LocalDateTime start = LocalDate.now().atTime(time, 0);
         LocalDateTime end = (time == 21)
-                ?LocalDate.now().plusDays(1).atStartOfDay()
-                :LocalDate.now().atTime(time+3,0);
-        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
-        return (float) Math.round(
-                roomConditions.stream()
-                        .mapToDouble(RoomCondition::getHumidity)
-                        .average()
-                        .orElse(0.0) * 10
-        ) / 10;
+                ? LocalDate.now().plusDays(1).atStartOfDay()
+                : LocalDate.now().atTime(time + 3, 0);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start, end);
+        return avgHumidity(roomConditions);
     }
 
     public float getHumidityAvgByDayAndTimeRange(int day, int time1, int time2, Long childId) {
         LocalDate now = LocalDate.now().minusDays(day);
-        LocalDateTime start = now.atTime(time1,0);
+        LocalDateTime start = now.atTime(time1, 0);
         LocalDateTime end = (time2 == 24)
                 ? now.plusDays(1).atStartOfDay()
                 : now.atTime(time2, 0);
-        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start, end);
+        return avgHumidity(roomConditions);
+    }
+
+    private float avgHumidity(List<RoomCondition> roomConditions) {
         return (float) Math.round(
                 roomConditions.stream()
                         .mapToDouble(RoomCondition::getHumidity)

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGenerator.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGenerator.java
@@ -1,0 +1,32 @@
+package final_project.momeasy.domain.humidity_graph.service;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.humidity_graph.dto.HumidityGraphResponseDTO;
+import final_project.momeasy.domain.humidity_graph.entity.HumidityGraph;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HumidityGenerator {
+    private final AvgHumidity avgHumidity;
+
+    public HumidityGraph HumidityGraph(FeverReport feverReport, int dayOffset, DayRange dayRange, int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.DAY1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        HumidityGraph humidityGraph = HumidityGraph.builder()
+                .avgHumidity(avg)
+                .dayRange(dayRange)
+                .build();
+        humidityGraph.setFeverReport(feverReport);
+        return humidityGraph;
+    }
+
+    public HumidityGraphResponseDTO.HumidityGraphHomecamViewDTO HomecamHumidityGraph(int dayOffset, DayRange dayRange, int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.DAY1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        return HumidityGraphResponseDTO.HumidityGraphHomecamViewDTO.builder()
+                .avghumidity(avg)
+                .dayRange(dayRange)
+                .build();
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/humidity_graph/service/HumidityGraphServiceImpl.java
@@ -22,26 +22,26 @@ import java.util.List;
 public class HumidityGraphServiceImpl implements HumidityGraphService {
     private final HumidityGraphRepositoy humidityGraphRepositoy;
     private final FeverReportRepository feverReportRepository;
-    private final AvgHumidity avgHumidity;
+    private final HumidityGenerator humidityGenerator;
 
     @Override
     public List<HumidityGraph> createHumidityRecordGraph(Long recordId, Parent parent, Long childId) {
-        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(() -> new FeverReportException(FeverReportErrorCode.NOT_FOUND));
 
         List<HumidityGraph> humidityGraphs = new ArrayList<>();
         // 범위 day1
-        for(int t = 0 ; t <24 ; t+=3){
-            humidityGraphs.add(buildHumidityGraph(feverReport, 0, DayRange.DAY1,t, t, childId));
+        for (int t = 0; t < 24; t += 3) {
+            humidityGraphs.add(humidityGenerator.HumidityGraph(feverReport, 0, DayRange.DAY1, t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY3,0, 6,childId));   // 새벽
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY3,6, 12,childId));  // 오전
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY3,12, 24,childId)); // 오후
+            humidityGraphs.add(humidityGenerator.HumidityGraph(feverReport, d, DayRange.DAY3, 0, 6, childId));   // 새벽
+            humidityGraphs.add(humidityGenerator.HumidityGraph(feverReport, d, DayRange.DAY3, 6, 12, childId));  // 오전
+            humidityGraphs.add(humidityGenerator.HumidityGraph(feverReport, d, DayRange.DAY3, 12, 24, childId)); // 오후
         }
         // 범위 day7
-        for(int d = 6; d>=0; d--){
-            humidityGraphs.add(buildHumidityGraph(feverReport, d, DayRange.DAY7,0, 24,childId));
+        for (int d = 6; d >= 0; d--) {
+            humidityGraphs.add(humidityGenerator.HumidityGraph(feverReport, d, DayRange.DAY7, 0, 24, childId));
         }
         humidityGraphRepositoy.saveAll(humidityGraphs);
         return humidityGraphs;
@@ -52,37 +52,19 @@ public class HumidityGraphServiceImpl implements HumidityGraphService {
 
         List<HumidityGraphResponseDTO.HumidityGraphHomecamViewDTO> humidityGraphs = new ArrayList<>();
         // 범위 day1
-        for(int t = 0 ; t <24 ; t+=3){
-            humidityGraphs.add(buildHomecamHumidityGraph(0, DayRange.DAY1,t, t, childId));
+        for (int t = 0; t < 24; t += 3) {
+            humidityGraphs.add(humidityGenerator.HomecamHumidityGraph(0, DayRange.DAY1, t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            humidityGraphs.add(buildHomecamHumidityGraph(d, DayRange.DAY3,0, 6,childId));   // 새벽
-            humidityGraphs.add(buildHomecamHumidityGraph(d, DayRange.DAY3,6, 12,childId));  // 오전
-            humidityGraphs.add(buildHomecamHumidityGraph(d, DayRange.DAY3,12, 24,childId)); // 오후
+            humidityGraphs.add(humidityGenerator.HomecamHumidityGraph(d, DayRange.DAY3, 0, 6, childId));   // 새벽
+            humidityGraphs.add(humidityGenerator.HomecamHumidityGraph(d, DayRange.DAY3, 6, 12, childId));  // 오전
+            humidityGraphs.add(humidityGenerator.HomecamHumidityGraph(d, DayRange.DAY3, 12, 24, childId)); // 오후
         }
         // 범위 day7
-        for(int d = 6; d>=0; d--){
-            humidityGraphs.add(buildHomecamHumidityGraph(d, DayRange.DAY7,0, 24,childId));
+        for (int d = 6; d >= 0; d--) {
+            humidityGraphs.add(humidityGenerator.HomecamHumidityGraph(d, DayRange.DAY7, 0, 24, childId));
         }
         return humidityGraphs;
-    }
-
-    private HumidityGraph buildHumidityGraph(FeverReport feverReport, int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.DAY1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
-        HumidityGraph humidityGraph = HumidityGraph.builder()
-                .avgHumidity(avg)
-                .dayRange(dayRange)
-                .build();
-        humidityGraph.setFeverReport(feverReport);
-        return humidityGraph;
-    }
-
-    private HumidityGraphResponseDTO.HumidityGraphHomecamViewDTO buildHomecamHumidityGraph(int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.DAY1 ? avgHumidity.getHumidityAvgBy3Hour(startHour, childId) : avgHumidity.getHumidityAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
-        return HumidityGraphResponseDTO.HumidityGraphHomecamViewDTO.builder()
-                .avghumidity(avg)
-                .dayRange(dayRange)
-                .build();
     }
 }

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionGraphGenerator.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionGraphGenerator.java
@@ -1,0 +1,63 @@
+package final_project.momeasy.domain.room_condition.service;
+
+import final_project.momeasy.domain.humidity_graph.service.AvgHumidity;
+import final_project.momeasy.domain.room_condition.dto.RoomConditionResponseDTO;
+import final_project.momeasy.domain.temperature_graph.service.AvgTemperature;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RoomConditionGraphGenerator {
+    private final AvgHumidity avgHumidity;
+    private final AvgTemperature avgTemperature;
+
+    public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> createDay1(Long childId) {
+        List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
+        for (int t = 0; t < 24; t += 3) {
+            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
+                    .avgtemperature(avgTemperature.getTemperatureAvgBy3Hour(t, childId))
+                    .avghumidity(avgHumidity.getHumidityAvgBy3Hour(t, childId))
+                    .build());
+        }
+        return result;
+    }
+
+    public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> createDay3(Long childId) {
+        List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
+        for (int d = 2; d >= 0; d--) {
+            // 새벽: 00:00 ~ 06:00
+            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
+                    .avgtemperature(avgTemperature.getTemperatureAvgByDayAndTimeRange(d, 0, 6, childId))
+                    .avghumidity(avgHumidity.getHumidityAvgByDayAndTimeRange(d, 0, 6, childId))
+                    .build());
+
+            // 오전: 06:00 ~ 12:00
+            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
+                    .avgtemperature(avgTemperature.getTemperatureAvgByDayAndTimeRange(d, 6, 12, childId))
+                    .avghumidity(avgHumidity.getHumidityAvgByDayAndTimeRange(d, 6, 12, childId))
+                    .build());
+
+            // 오후: 12:00 ~ 24:00
+            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
+                    .avgtemperature(avgTemperature.getTemperatureAvgByDayAndTimeRange(d, 12, 24, childId))
+                    .avghumidity(avgHumidity.getHumidityAvgByDayAndTimeRange(d, 12, 24, childId))
+                    .build());
+        }
+        return result;
+    }
+
+    public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> createDay7(Long childId) {
+        List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
+        for (int d = 6; d >= 0; d--) {
+            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
+                    .avgtemperature(avgTemperature.getTemperatureAvgByDayAndTimeRange(d, 0, 24, childId))
+                    .avghumidity(avgHumidity.getHumidityAvgByDayAndTimeRange(d, 0, 24, childId))
+                    .build());
+        }
+        return result;
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/room_condition/service/RoomConditionQueryServiceImpl.java
@@ -3,7 +3,6 @@ package final_project.momeasy.domain.room_condition.service;
 import final_project.momeasy.domain.child.exception.ChildErrorCode;
 import final_project.momeasy.domain.child.exception.ChildException;
 import final_project.momeasy.domain.child.repository.ChildRepository;
-import final_project.momeasy.domain.humidity_graph.service.AvgHumidity;
 import final_project.momeasy.domain.parent.entity.Parent;
 import final_project.momeasy.domain.room_condition.converter.RoomConditionConverter;
 import final_project.momeasy.domain.room_condition.dto.RoomConditionResponseDTO;
@@ -11,38 +10,34 @@ import final_project.momeasy.domain.room_condition.entity.RoomCondition;
 import final_project.momeasy.domain.room_condition.exception.RoomConditionErrorCode;
 import final_project.momeasy.domain.room_condition.exception.RoomConditionException;
 import final_project.momeasy.domain.room_condition.repository.RoomConditionRepository;
-import final_project.momeasy.domain.temperature_graph.service.AvgTemperature;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RoomConditionQueryServiceImpl implements RoomConditionQueryService {
     private final RoomConditionRepository roomConditionRepository;
     private final ChildRepository childRepository;
-    private final AvgHumidity avgHumidity;
-    private final AvgTemperature avgTemperature;
+    private final RoomConditionGraphGenerator roomConditionGraphGenerator;
 
     @Override
     public RoomConditionResponseDTO.RoomConditionViewDTO getRoomCondition(Long childId, Parent parent) {
-        childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        childRepository.findById(childId).orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
         if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
             throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
-        RoomCondition roomCondition = roomConditionRepository.findTopByChildIdOrderByCreatedAtDesc(childId).orElseThrow(()->new RoomConditionException(RoomConditionErrorCode.NOT_FOUND));
+        RoomCondition roomCondition = roomConditionRepository.findTopByChildIdOrderByCreatedAtDesc(childId).orElseThrow(() -> new RoomConditionException(RoomConditionErrorCode.NOT_FOUND));
         return RoomConditionConverter.toRoomConditionViewDTO(roomCondition);
     }
 
     @Override
     public RoomConditionResponseDTO.RoomConditionListViewDTO getRoomConditionPage(Long childId, Long cursor, Integer size, Parent parent) {
-        childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
+        childRepository.findById(childId).orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
         if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
             throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -53,76 +48,42 @@ public class RoomConditionQueryServiceImpl implements RoomConditionQueryService 
         Slice<RoomCondition> roomConditionList = roomConditionRepository.findRoomConditionCursorPagination(childId, cursor, pageable);
         List<RoomCondition> roomConditions = roomConditionList.toList();
         List<RoomConditionResponseDTO.RoomConditionViewDTO> roomConditionViewDTOS = roomConditions.stream().map(RoomConditionConverter::toRoomConditionViewDTO).toList();
-        if(roomConditionList.isEmpty()){
+        if (roomConditionList.isEmpty()) {
             throw new RoomConditionException(RoomConditionErrorCode.NOT_FOUND);
         }
 
         Long nextCursor = null;
-        if(!roomConditions.isEmpty() && roomConditionList.hasNext()) {
-            nextCursor = roomConditions.get(roomConditions.size()-1).getId();
+        if (!roomConditions.isEmpty() && roomConditionList.hasNext()) {
+            nextCursor = roomConditions.get(roomConditions.size() - 1).getId();
         }
-        
-        return RoomConditionConverter.toRoomConditionListViewDTO(roomConditionViewDTOS,roomConditionList.hasNext(),nextCursor);
+
+        return RoomConditionConverter.toRoomConditionListViewDTO(roomConditionViewDTOS, roomConditionList.hasNext(), nextCursor);
     }
 
     @Override
     public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> getRoomConditionGraphDay1(Long childId, Parent parent) {
-        childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
+        childRepository.findById(childId).orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
+        if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
             throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
-        List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
-        for(int t = 0 ; t <24 ; t+=3){
-            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
-                            .avgtemperature(avgHumidity.getHumidityAvgBy3Hour(t,childId))
-                            .avghumidity(avgTemperature.getTemperatureAvgBy3Hour(t,childId))
-                    .build());
-        }
-        return result;
+        return roomConditionGraphGenerator.createDay1(childId);
     }
 
     @Override
     public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> getRoomConditionGraphDay3(Long childId, Parent parent) {
-        childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
+        childRepository.findById(childId).orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
+        if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
             throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
-        List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
-        for(int d=2; d>=0; d--) {
-            // 새벽: 00:00 ~ 06:00
-            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
-                    .avgtemperature(avgHumidity.getHumidityAvgByDayAndTimeRange(d,0,6,childId))
-                    .avghumidity(avgTemperature.getTemperatureAvgByDayAndTimeRange(d,0,6,childId))
-                    .build());
-
-            // 오전: 06:00 ~ 12:00
-            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
-                    .avgtemperature(avgHumidity.getHumidityAvgByDayAndTimeRange(d,6,12,childId))
-                    .avghumidity(avgTemperature.getTemperatureAvgByDayAndTimeRange(d,6,12,childId))
-                    .build());
-
-            // 오후: 12:00 ~ 24:00
-            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
-                    .avghumidity(avgHumidity.getHumidityAvgByDayAndTimeRange(d,12,24,childId))
-                    .avgtemperature(avgTemperature.getTemperatureAvgByDayAndTimeRange(d,12,24,childId))
-                    .build());
-        }
-        return result;
+        return roomConditionGraphGenerator.createDay3(childId);
     }
 
     @Override
     public List<RoomConditionResponseDTO.RoomConditionGrpahDTO> getRoomConditionGraphDay7(Long childId, Parent parent) {
-        childRepository.findById(childId).orElseThrow(()->new ChildException(ChildErrorCode.NOT_FOUND));
-        if(!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
+        childRepository.findById(childId).orElseThrow(() -> new ChildException(ChildErrorCode.NOT_FOUND));
+        if (!childRepository.existsByChildIdAndParentId(childId, parent.getId())) {
             throw new RoomConditionException(RoomConditionErrorCode.UNAUTHORIZED_ACCESS);
         }
-        List<RoomConditionResponseDTO.RoomConditionGrpahDTO> result = new ArrayList<>();
-        for(int d = 6; d>=0; d--){
-            result.add(RoomConditionResponseDTO.RoomConditionGrpahDTO.builder()
-                    .avghumidity(avgHumidity.getHumidityAvgByDayAndTimeRange(d,0,24,childId))
-                    .avgtemperature(avgTemperature.getTemperatureAvgByDayAndTimeRange(d,0,24,childId))
-                    .build());
-        }
-        return result;
+        return roomConditionGraphGenerator.createDay7(childId);
     }
 }

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/AvgTemperature.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/AvgTemperature.java
@@ -15,26 +15,25 @@ public class AvgTemperature {
     private final RoomConditionRepository roomConditionRepository;
 
     public float getTemperatureAvgBy3Hour(int time, Long childId) {
-        LocalDateTime start = LocalDate.now().atTime(time,0);
+        LocalDateTime start = LocalDate.now().atTime(time, 0);
         LocalDateTime end = (time == 21)
-                ?LocalDate.now().plusDays(1).atStartOfDay()
-                :LocalDate.now().atTime(time+3,0);
-        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId,start,end);
-        return (float) Math.round(
-                roomConditions.stream()
-                        .mapToDouble(RoomCondition::getTemperature)
-                        .average()
-                        .orElse(0.0) * 10
-        ) / 10;
+                ? LocalDate.now().plusDays(1).atStartOfDay()
+                : LocalDate.now().atTime(time + 3, 0);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start, end);
+        return avgTemperature(roomConditions);
     }
 
     public float getTemperatureAvgByDayAndTimeRange(int day, int time1, int time2, Long childId) {
         LocalDate now = LocalDate.now().minusDays(day);
-        LocalDateTime start = now.atTime(time1,0);
+        LocalDateTime start = now.atTime(time1, 0);
         LocalDateTime end = (time2 == 24)
                 ? now.plusDays(1).atStartOfDay()
                 : now.atTime(time2, 0);
-        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start,end);
+        List<RoomCondition> roomConditions = roomConditionRepository.findByChildIdAndCreatedAtBetween(childId, start, end);
+        return avgTemperature(roomConditions);
+    }
+
+    private float avgTemperature(List<RoomCondition> roomConditions) {
         return (float) Math.round(
                 roomConditions.stream()
                         .mapToDouble(RoomCondition::getTemperature)

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGenerator.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGenerator.java
@@ -1,0 +1,33 @@
+package final_project.momeasy.domain.temperature_graph.service;
+
+import final_project.momeasy.common.enums.DayRange;
+import final_project.momeasy.domain.fever_report.entity.FeverReport;
+import final_project.momeasy.domain.temperature_graph.dto.TemperatureGraphResponseDTO;
+import final_project.momeasy.domain.temperature_graph.entity.TemperatureGraph;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TemperatureGenerator {
+    private final AvgTemperature avgTemperature;
+
+    public TemperatureGraph TemperatureGraph(FeverReport feverReport, int dayOffset, DayRange dayRange, int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.DAY1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        TemperatureGraph temperatureGraph = TemperatureGraph.builder()
+                .avgTemperature(avg)
+                .dayRange(dayRange)
+                .build();
+        temperatureGraph.setFeverReport(feverReport);
+        return temperatureGraph;
+    }
+
+    public TemperatureGraphResponseDTO.TemperatureGraphHomecamViewDTO HomecamTemperatureGraph(int dayOffset, DayRange dayRange, int startHour, int endHour, Long childId) {
+        float avg = dayRange == DayRange.DAY1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
+        return TemperatureGraphResponseDTO.TemperatureGraphHomecamViewDTO.builder()
+                .avgtemperature(avg)
+                .dayRange(dayRange)
+                .build();
+
+    }
+}

--- a/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphServiceImpl.java
+++ b/src/main/java/final_project/momeasy/domain/temperature_graph/service/TemperatureGraphServiceImpl.java
@@ -22,26 +22,26 @@ import java.util.List;
 public class TemperatureGraphServiceImpl implements TemperatureGraphService {
     private final TemperatureGraphRepository temperatureGraphRepository;
     private final FeverReportRepository feverReportRepository;
-    private final AvgTemperature avgTemperature;
+    private final TemperatureGenerator temperatureGenerator;
 
     @Override
     public List<TemperatureGraph> createTemperatureRecordGraph(Long recordId, Parent parent, Long childId) {
-        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(()->new FeverReportException(FeverReportErrorCode.NOT_FOUND));
+        FeverReport feverReport = feverReportRepository.findById(recordId).orElseThrow(() -> new FeverReportException(FeverReportErrorCode.NOT_FOUND));
 
         List<TemperatureGraph> temperatureGraphs = new ArrayList<>();
         // 범위 day1
-        for(int t = 0 ; t <24 ; t+=3){
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, 0, DayRange.DAY1,t, t, childId));
+        for (int t = 0; t < 24; t += 3) {
+            temperatureGraphs.add(temperatureGenerator.TemperatureGraph(feverReport, 0, DayRange.DAY1, t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY3,0, 6,childId));   // 새벽
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY3,6, 12,childId));  // 오전
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY3,12, 24,childId)); // 오후
+            temperatureGraphs.add(temperatureGenerator.TemperatureGraph(feverReport, d, DayRange.DAY3, 0, 6, childId));   // 새벽
+            temperatureGraphs.add(temperatureGenerator.TemperatureGraph(feverReport, d, DayRange.DAY3, 6, 12, childId));  // 오전
+            temperatureGraphs.add(temperatureGenerator.TemperatureGraph(feverReport, d, DayRange.DAY3, 12, 24, childId)); // 오후
         }
         // 범위 day7
-        for(int d = 6; d>=0; d--){
-            temperatureGraphs.add(buildTemperatureGraph(feverReport, d, DayRange.DAY7,0, 24,childId));
+        for (int d = 6; d >= 0; d--) {
+            temperatureGraphs.add(temperatureGenerator.TemperatureGraph(feverReport, d, DayRange.DAY7, 0, 24, childId));
         }
         temperatureGraphRepository.saveAll(temperatureGraphs);
         return temperatureGraphs;
@@ -51,38 +51,19 @@ public class TemperatureGraphServiceImpl implements TemperatureGraphService {
     public List<TemperatureGraphResponseDTO.TemperatureGraphHomecamViewDTO> getTemperatureRecordHomecamGraph(Parent parent, Long childId) {
         List<TemperatureGraphResponseDTO.TemperatureGraphHomecamViewDTO> temperatureGraphs = new ArrayList<>();
         // 범위 day1
-        for(int t = 0 ; t <24 ; t+=3){
-            temperatureGraphs.add(buildHomecamTemperatureGraph(0, DayRange.DAY1,t, t, childId));
+        for (int t = 0; t < 24; t += 3) {
+            temperatureGraphs.add(temperatureGenerator.HomecamTemperatureGraph(0, DayRange.DAY1, t, t, childId));
         }
         // 범위 day3
         for (int d = 2; d >= 0; d--) {
-            temperatureGraphs.add(buildHomecamTemperatureGraph(d, DayRange.DAY3,0, 6,childId));   // 새벽
-            temperatureGraphs.add(buildHomecamTemperatureGraph(d, DayRange.DAY3,6, 12,childId));  // 오전
-            temperatureGraphs.add(buildHomecamTemperatureGraph(d, DayRange.DAY3,12, 24,childId)); // 오후
+            temperatureGraphs.add(temperatureGenerator.HomecamTemperatureGraph(d, DayRange.DAY3, 0, 6, childId));   // 새벽
+            temperatureGraphs.add(temperatureGenerator.HomecamTemperatureGraph(d, DayRange.DAY3, 6, 12, childId));  // 오전
+            temperatureGraphs.add(temperatureGenerator.HomecamTemperatureGraph(d, DayRange.DAY3, 12, 24, childId)); // 오후
         }
         // 범위 day7
-        for(int d = 6; d>=0; d--){
-            temperatureGraphs.add(buildHomecamTemperatureGraph(d, DayRange.DAY7,0, 24,childId));
+        for (int d = 6; d >= 0; d--) {
+            temperatureGraphs.add(temperatureGenerator.HomecamTemperatureGraph(d, DayRange.DAY7, 0, 24, childId));
         }
         return temperatureGraphs;
-    }
-
-    private TemperatureGraph buildTemperatureGraph(FeverReport feverReport, int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.DAY1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
-        TemperatureGraph temperatureGraph = TemperatureGraph.builder()
-                .avgTemperature(avg)
-                .dayRange(dayRange)
-                .build();
-        temperatureGraph.setFeverReport(feverReport);
-        return temperatureGraph;
-    }
-
-    private TemperatureGraphResponseDTO.TemperatureGraphHomecamViewDTO buildHomecamTemperatureGraph(int dayOffset, DayRange dayRange , int startHour, int endHour, Long childId) {
-        float avg = dayRange == DayRange.DAY1 ? avgTemperature.getTemperatureAvgBy3Hour(startHour, childId) : avgTemperature.getTemperatureAvgByDayAndTimeRange(dayOffset, startHour, endHour, childId);
-        return TemperatureGraphResponseDTO.TemperatureGraphHomecamViewDTO.builder()
-                .avgtemperature(avg)
-                .dayRange(dayRange)
-                .build();
-
     }
 }


### PR DESCRIPTION
## 🔘Part

- [x] SRP 위반 부분
- [x] 온도/습도 불일치 부분 수정
- [x] 컨벤션

  <br/>
## ➕ 이슈 링크

- #217 

<br/>

## 🔎 작업 내용

### 큰 문제점
- RoomConditionQueryServiceImpl의 getRoomConditionGraphDay은 사용하지 않는 함수기 때문에 온도/습도가 바뀌어도 서비스가 잘 작동했음..
- 하지만 리팩토링 연습을 위해 코드 수정

### 작업 상세 내용
- AvgFever, AvgTemperature은 서비스에서 사용 중인 graph 생성 코드에서 사용됨. 동시에 서비스에서 사용하지 않는 RoomConditionQueryServiceImpl에서도 사용됨. 우선, 두 개의 파일에서 AvgFever, AvgTemperature을 사용하는 구조로 유지하면서 리팩토링 진행
- RoomConditionGraphGenerator를 통해 RoomConditionQueryServiceImpl SRP 적용
- AvgFever, AvgTemperature, AvgHumidity 평균값 계산 부분 코드 분리
- 온도/습도 불일치 수정
- GraphServiceImpl에 평균값 계산/객체 반환하는 코드 분리
